### PR TITLE
Feat/261 vds simple endpoint authentiction

### DIFF
--- a/.flake/flake.lock
+++ b/.flake/flake.lock
@@ -34,13 +34,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/.flake/flake.nix
+++ b/.flake/flake.nix
@@ -1,23 +1,33 @@
 {
   description = "Dependencies";
 
-  inputs.nixpkgs_unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
-  # inputs.nixpkgs.url = "github.com/identinet/nixpkgs/identinet";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-
+  inputs = {
+    # nixpkgs.url = "github.com/identinet/nixpkgs/identinet";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        unstable = nixpkgs_unstable.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
         allOsPackages = with pkgs; [
           bashInteractive # bash used in scripts
           caddy # HTTP server https://caddyserver.com/

--- a/Justfile
+++ b/Justfile
@@ -81,7 +81,7 @@ dev: githooks
                       response: {
                         add: {
                           # CORS: allow fetching from everywhere for development purposes
-                          Access-Control-Allow-Origin: [*]
+                          Access-Control-Allow-Origin: ["{http.request.header.Origin}"]
                         }
                       }
                     }
@@ -119,7 +119,7 @@ dev: githooks
                       response: {
                         add: {
                           # CORS: allow fetching from everywhere for development purposes
-                          Access-Control-Allow-Origin: [*]
+                          Access-Control-Allow-Origin: ["{http.request.header.Origin}"]
                         }
                       }
                     }

--- a/Justfile
+++ b/Justfile
@@ -77,6 +77,15 @@ dev: githooks
                   match: ($service | getHosts | each {|hostname| {host: [$hostname]}})
                   handle: [
                     {
+                      handler: "headers"
+                      response: {
+                        add: {
+                          # CORS: allow fetching from everywhere for development purposes
+                          Access-Control-Allow-Origin: [*]
+                        }
+                      }
+                    }
+                    {
                       handler: "encode"
                       encodings: { gzip: {level: 3} zstd: {level: "default"} }
                     }
@@ -105,6 +114,15 @@ dev: githooks
                 {
                   match: ($service | getHosts --no-tunnel | each {|hostname| {host: [$hostname]}})
                   handle: [
+                    {
+                      handler: "headers"
+                      response: {
+                        add: {
+                          # CORS: allow fetching from everywhere for development purposes
+                          Access-Control-Allow-Origin: [*]
+                        }
+                      }
+                    }
                     {
                       handler: "encode"
                       encodings: { gzip: {level: 3} zstd: {level: "default"} }

--- a/services/demo-shop/.env
+++ b/services/demo-shop/.env
@@ -7,8 +7,12 @@ SERVICE_NAME=shop
 # External hostname
 EXTERNAL_HOSTNAME=${TUNNEL_USER}-${SERVICE_NAME}.${TUNNEL_DOMAIN}
 INTERNAL_HOSTNAME=${SERVICE_NAME}.com.localhost
+# External hostname of the Verifiable Service
+EXTERNAL_VSI_HOSTNAME=${TUNNEL_USER}-check.${TUNNEL_DOMAIN}
 # External hostname of the Verifiable Data Service
 EXTERNAL_VDS_HOSTNAME=${TUNNEL_USER}-vds.${TUNNEL_DOMAIN}
+# authorization token for accessing protected /authrequests endpoints
+VDS_BEARER_TOKEN=testest
 # External hostname of the Embedded Verification Interface
 EXTERNAL_EVI_HOSTNAME=${TUNNEL_USER}-evi.${TUNNEL_DOMAIN}
 # EXTERNAL_EVI_HOSTNAME=evi.identinet.io.localhost

--- a/services/demo-shop/app.config.ts
+++ b/services/demo-shop/app.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "@solidjs/start/config";
 import UnoCSS from "unocss/vite";
 import presetWind4 from "@unocss/preset-wind4";
 import { presetIcons } from "unocss";
+import process from "node:process";
 
 /**
  * TODO flowbite preset is outdated, we probably want to update the included preflight CSS results with the CSS provided

--- a/services/demo-shop/deno.jsonc
+++ b/services/demo-shop/deno.jsonc
@@ -1,5 +1,9 @@
 // Documentation: https://docs.deno.com/runtime/manual/getting_started/configuration_file
 {
+  // workaround to make ./tsconfig.json's paths work in deno
+  "imports": {
+    "~/": "./src/"
+  },
   "fmt": {
     "useTabs": false,
     "lineWidth": 120,

--- a/services/demo-shop/deno.lock
+++ b/services/demo-shop/deno.lock
@@ -3,15 +3,15 @@
   "specifiers": {
     "npm:@iconify-json/flowbite@^1.2.5": "1.2.5",
     "npm:@solidjs/router@0.15": "0.15.3_solid-js@1.9.7__seroval@1.3.1",
-    "npm:@solidjs/start@^1.1.4": "1.1.4_vinxi@0.5.6__@babel+core@7.27.1_seroval@1.3.1_solid-js@1.9.7__seroval@1.3.1",
-    "npm:@unocss/preset-wind4@^66.1.3": "66.1.3",
+    "npm:@solidjs/start@^1.1.4": "1.1.4_vinxi@0.5.7__@babel+core@7.27.4_seroval@1.3.1_solid-js@1.9.7__seroval@1.3.1",
+    "npm:@unocss/preset-wind4@^66.2.0": "66.2.0",
     "npm:@vonagam/unocss-preset-flowbite@^0.0.1": "0.0.1_@unocss+core@0.65.4",
     "npm:flowbite@^3.1.2": "3.1.2",
-    "npm:iovalkey@~0.3.2": "0.3.2",
+    "npm:iovalkey@~0.3.3": "0.3.3",
     "npm:lean-qr@^2.5.0": "2.5.0",
     "npm:solid-js@^1.9.7": "1.9.7_seroval@1.3.1",
-    "npm:unocss@^66.1.3": "66.1.3",
-    "npm:vinxi@~0.5.6": "0.5.6_@babel+core@7.27.1"
+    "npm:unocss@^66.2.0": "66.2.0",
+    "npm:vinxi@~0.5.7": "0.5.7_@babel+core@7.27.4"
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -47,11 +47,11 @@
         "picocolors"
       ]
     },
-    "@babel/compat-data@7.27.2": {
-      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ=="
+    "@babel/compat-data@7.27.5": {
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg=="
     },
-    "@babel/core@7.27.1": {
-      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+    "@babel/core@7.27.4": {
+      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dependencies": [
         "@ampproject/remapping",
         "@babel/code-frame@7.27.1",
@@ -64,20 +64,26 @@
         "@babel/traverse",
         "@babel/types",
         "convert-source-map",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "gensync",
         "json5",
         "semver@6.3.1"
       ]
     },
-    "@babel/generator@7.27.1": {
-      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+    "@babel/generator@7.27.5": {
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
         "@jridgewell/gen-mapping",
         "@jridgewell/trace-mapping",
         "jsesc"
+      ]
+    },
+    "@babel/helper-annotate-as-pure@7.27.3": {
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dependencies": [
+        "@babel/types"
       ]
     },
     "@babel/helper-compilation-targets@7.27.2": {
@@ -88,6 +94,26 @@
         "browserslist",
         "lru-cache@5.1.1",
         "semver@6.3.1"
+      ]
+    },
+    "@babel/helper-create-class-features-plugin@7.27.1_@babel+core@7.27.4": {
+      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-annotate-as-pure",
+        "@babel/helper-member-expression-to-functions",
+        "@babel/helper-optimise-call-expression",
+        "@babel/helper-replace-supers",
+        "@babel/helper-skip-transparent-expression-wrappers",
+        "@babel/traverse",
+        "semver@6.3.1"
+      ]
+    },
+    "@babel/helper-member-expression-to-functions@7.27.1": {
+      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
       ]
     },
     "@babel/helper-module-imports@7.18.6": {
@@ -103,8 +129,8 @@
         "@babel/types"
       ]
     },
-    "@babel/helper-module-transforms@7.27.1_@babel+core@7.27.1": {
-      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+    "@babel/helper-module-transforms@7.27.3_@babel+core@7.27.4": {
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "dependencies": [
         "@babel/core",
         "@babel/helper-module-imports@7.27.1",
@@ -112,8 +138,30 @@
         "@babel/traverse"
       ]
     },
+    "@babel/helper-optimise-call-expression@7.27.1": {
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dependencies": [
+        "@babel/types"
+      ]
+    },
     "@babel/helper-plugin-utils@7.27.1": {
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw=="
+    },
+    "@babel/helper-replace-supers@7.27.1_@babel+core@7.27.4": {
+      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-member-expression-to-functions",
+        "@babel/helper-optimise-call-expression",
+        "@babel/traverse"
+      ]
+    },
+    "@babel/helper-skip-transparent-expression-wrappers@7.27.1": {
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dependencies": [
+        "@babel/traverse",
+        "@babel/types"
+      ]
     },
     "@babel/helper-string-parser@7.27.1": {
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
@@ -124,31 +172,61 @@
     "@babel/helper-validator-option@7.27.1": {
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="
     },
-    "@babel/helpers@7.27.1": {
-      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+    "@babel/helpers@7.27.6": {
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dependencies": [
         "@babel/template",
         "@babel/types"
       ]
     },
-    "@babel/parser@7.27.2": {
-      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+    "@babel/parser@7.27.5": {
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dependencies": [
         "@babel/types"
       ]
     },
-    "@babel/plugin-syntax-jsx@7.27.1_@babel+core@7.27.1": {
+    "@babel/plugin-syntax-jsx@7.27.1_@babel+core@7.27.4": {
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dependencies": [
         "@babel/core",
         "@babel/helper-plugin-utils"
       ]
     },
-    "@babel/plugin-syntax-typescript@7.27.1_@babel+core@7.27.1": {
+    "@babel/plugin-syntax-typescript@7.27.1_@babel+core@7.27.4": {
       "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dependencies": [
         "@babel/core",
         "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-transform-modules-commonjs@7.27.1_@babel+core@7.27.4": {
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-module-transforms",
+        "@babel/helper-plugin-utils"
+      ]
+    },
+    "@babel/plugin-transform-typescript@7.27.1_@babel+core@7.27.4": {
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-annotate-as-pure",
+        "@babel/helper-create-class-features-plugin",
+        "@babel/helper-plugin-utils",
+        "@babel/helper-skip-transparent-expression-wrappers",
+        "@babel/plugin-syntax-typescript"
+      ]
+    },
+    "@babel/preset-typescript@7.27.1_@babel+core@7.27.4": {
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/helper-plugin-utils",
+        "@babel/helper-validator-option",
+        "@babel/plugin-syntax-jsx",
+        "@babel/plugin-transform-modules-commonjs",
+        "@babel/plugin-transform-typescript"
       ]
     },
     "@babel/template@7.27.2": {
@@ -159,20 +237,20 @@
         "@babel/types"
       ]
     },
-    "@babel/traverse@7.27.1": {
-      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+    "@babel/traverse@7.27.4": {
+      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
       "dependencies": [
         "@babel/code-frame@7.27.1",
         "@babel/generator",
         "@babel/parser",
         "@babel/template",
         "@babel/types",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "globals@11.12.0"
       ]
     },
-    "@babel/types@7.27.1": {
-      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+    "@babel/types@7.27.6": {
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
@@ -205,162 +283,87 @@
         "which@4.0.0"
       ]
     },
-    "@dependents/detective-less@4.1.0": {
-      "integrity": "sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==",
+    "@dependents/detective-less@5.0.1": {
+      "integrity": "sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==",
       "dependencies": [
         "gonzales-pe",
         "node-source-walk"
       ]
     },
-    "@esbuild/aix-ppc64@0.24.2": {
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="
+    "@esbuild/aix-ppc64@0.25.5": {
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA=="
     },
-    "@esbuild/aix-ppc64@0.25.4": {
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="
+    "@esbuild/android-arm64@0.25.5": {
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg=="
     },
-    "@esbuild/android-arm64@0.24.2": {
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="
+    "@esbuild/android-arm@0.25.5": {
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA=="
     },
-    "@esbuild/android-arm64@0.25.4": {
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A=="
+    "@esbuild/android-x64@0.25.5": {
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw=="
     },
-    "@esbuild/android-arm@0.24.2": {
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="
+    "@esbuild/darwin-arm64@0.25.5": {
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ=="
     },
-    "@esbuild/android-arm@0.25.4": {
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="
+    "@esbuild/darwin-x64@0.25.5": {
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ=="
     },
-    "@esbuild/android-x64@0.24.2": {
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="
+    "@esbuild/freebsd-arm64@0.25.5": {
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw=="
     },
-    "@esbuild/android-x64@0.25.4": {
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ=="
+    "@esbuild/freebsd-x64@0.25.5": {
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw=="
     },
-    "@esbuild/darwin-arm64@0.24.2": {
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="
+    "@esbuild/linux-arm64@0.25.5": {
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg=="
     },
-    "@esbuild/darwin-arm64@0.25.4": {
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g=="
+    "@esbuild/linux-arm@0.25.5": {
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw=="
     },
-    "@esbuild/darwin-x64@0.24.2": {
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="
+    "@esbuild/linux-ia32@0.25.5": {
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA=="
     },
-    "@esbuild/darwin-x64@0.25.4": {
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A=="
+    "@esbuild/linux-loong64@0.25.5": {
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg=="
     },
-    "@esbuild/freebsd-arm64@0.24.2": {
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="
+    "@esbuild/linux-mips64el@0.25.5": {
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg=="
     },
-    "@esbuild/freebsd-arm64@0.25.4": {
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ=="
+    "@esbuild/linux-ppc64@0.25.5": {
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ=="
     },
-    "@esbuild/freebsd-x64@0.24.2": {
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="
+    "@esbuild/linux-riscv64@0.25.5": {
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA=="
     },
-    "@esbuild/freebsd-x64@0.25.4": {
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ=="
+    "@esbuild/linux-s390x@0.25.5": {
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ=="
     },
-    "@esbuild/linux-arm64@0.24.2": {
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="
+    "@esbuild/linux-x64@0.25.5": {
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw=="
     },
-    "@esbuild/linux-arm64@0.25.4": {
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ=="
+    "@esbuild/netbsd-arm64@0.25.5": {
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw=="
     },
-    "@esbuild/linux-arm@0.24.2": {
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="
+    "@esbuild/netbsd-x64@0.25.5": {
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ=="
     },
-    "@esbuild/linux-arm@0.25.4": {
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ=="
+    "@esbuild/openbsd-arm64@0.25.5": {
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw=="
     },
-    "@esbuild/linux-ia32@0.24.2": {
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="
+    "@esbuild/openbsd-x64@0.25.5": {
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg=="
     },
-    "@esbuild/linux-ia32@0.25.4": {
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ=="
+    "@esbuild/sunos-x64@0.25.5": {
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA=="
     },
-    "@esbuild/linux-loong64@0.24.2": {
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="
+    "@esbuild/win32-arm64@0.25.5": {
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw=="
     },
-    "@esbuild/linux-loong64@0.25.4": {
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA=="
+    "@esbuild/win32-ia32@0.25.5": {
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ=="
     },
-    "@esbuild/linux-mips64el@0.24.2": {
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="
-    },
-    "@esbuild/linux-mips64el@0.25.4": {
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg=="
-    },
-    "@esbuild/linux-ppc64@0.24.2": {
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="
-    },
-    "@esbuild/linux-ppc64@0.25.4": {
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag=="
-    },
-    "@esbuild/linux-riscv64@0.24.2": {
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="
-    },
-    "@esbuild/linux-riscv64@0.25.4": {
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA=="
-    },
-    "@esbuild/linux-s390x@0.24.2": {
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="
-    },
-    "@esbuild/linux-s390x@0.25.4": {
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g=="
-    },
-    "@esbuild/linux-x64@0.24.2": {
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="
-    },
-    "@esbuild/linux-x64@0.25.4": {
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA=="
-    },
-    "@esbuild/netbsd-arm64@0.24.2": {
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="
-    },
-    "@esbuild/netbsd-arm64@0.25.4": {
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ=="
-    },
-    "@esbuild/netbsd-x64@0.24.2": {
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="
-    },
-    "@esbuild/netbsd-x64@0.25.4": {
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw=="
-    },
-    "@esbuild/openbsd-arm64@0.24.2": {
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="
-    },
-    "@esbuild/openbsd-arm64@0.25.4": {
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A=="
-    },
-    "@esbuild/openbsd-x64@0.24.2": {
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="
-    },
-    "@esbuild/openbsd-x64@0.25.4": {
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw=="
-    },
-    "@esbuild/sunos-x64@0.24.2": {
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="
-    },
-    "@esbuild/sunos-x64@0.25.4": {
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q=="
-    },
-    "@esbuild/win32-arm64@0.24.2": {
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="
-    },
-    "@esbuild/win32-arm64@0.25.4": {
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ=="
-    },
-    "@esbuild/win32-ia32@0.24.2": {
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="
-    },
-    "@esbuild/win32-ia32@0.25.4": {
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="
-    },
-    "@esbuild/win32-x64@0.24.2": {
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="
-    },
-    "@esbuild/win32-x64@0.25.4": {
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="
+    "@esbuild/win32-x64@0.25.5": {
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g=="
     },
     "@fastify/busboy@3.1.1": {
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="
@@ -380,7 +383,7 @@
         "@antfu/install-pkg",
         "@antfu/utils",
         "@iconify/types",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "globals@15.15.0",
         "kolorist",
         "local-pkg",
@@ -407,7 +410,7 @@
     "@isaacs/fs-minipass@4.0.1": {
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dependencies": [
-        "minipass@7.1.2"
+        "minipass"
       ]
     },
     "@jridgewell/gen-mapping@0.3.8": {
@@ -441,51 +444,37 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
-    "@mapbox/node-pre-gyp@1.0.11": {
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "dependencies": [
-        "detect-libc@2.0.4",
-        "https-proxy-agent@5.0.1",
-        "make-dir",
-        "node-fetch@2.7.0",
-        "nopt@5.0.0",
-        "npmlog",
-        "rimraf",
-        "semver@7.7.2",
-        "tar@6.2.1"
-      ]
-    },
     "@mapbox/node-pre-gyp@2.0.0": {
       "integrity": "sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==",
       "dependencies": [
         "consola",
         "detect-libc@2.0.4",
-        "https-proxy-agent@7.0.6",
+        "https-proxy-agent",
         "node-fetch@2.7.0",
-        "nopt@8.1.0",
+        "nopt",
         "semver@7.7.2",
-        "tar@7.4.3"
+        "tar"
       ]
     },
     "@netlify/binary-info@1.0.0": {
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="
     },
-    "@netlify/blobs@9.1.1": {
-      "integrity": "sha512-hOrWBMOvdh9oa+8Z6ocvkY92q9YtfD+Vbh2i+Qs14cHsl9SYxRzPRQnBxU/H6PNtj6gtEJ7tv8RbBN8z7jH2jA==",
+    "@netlify/blobs@9.1.2": {
+      "integrity": "sha512-7dMjExSH4zj4ShvLem49mE3mf0K171Tx2pV4WDWhJbRUWW3SJIR2qntz0LvUGS97N5HO1SmnzrgWUhEXCsApiw==",
       "dependencies": [
         "@netlify/dev-utils",
         "@netlify/runtime-utils"
       ]
     },
-    "@netlify/dev-utils@2.1.1": {
-      "integrity": "sha512-0O4/eEcmZCNUkpSuN/yYRkX6BAcK/sbnH0YYNuK3HX193QXaSBT60TUpvTpiRxI6zvIfYCDRl3rz63w8m/lEMg==",
+    "@netlify/dev-utils@2.2.0": {
+      "integrity": "sha512-5XUvZuffe3KetyhbWwd4n2ktd7wraocCYw10tlM+/u/95iAz29GjNiuNxbCD1T6Bn1MyGc4QLVNKOWhzJkVFAw==",
       "dependencies": [
         "@whatwg-node/server",
         "chokidar@4.0.3",
         "decache",
         "dot-prop",
         "env-paths",
-        "find-up@7.0.0",
+        "find-up",
         "lodash.debounce",
         "netlify",
         "parse-gitignore",
@@ -493,12 +482,12 @@
         "write-file-atomic"
       ]
     },
-    "@netlify/functions@3.1.8_rollup@4.40.2": {
-      "integrity": "sha512-oAHPyybBx4oH8+3RfgihrTVhv6gseQw1pt0k4kZ/NDmGbEsgrr3gw+3ajzM5+fW5UnWiNuR5c+d7JgtRqjyMkw==",
+    "@netlify/functions@3.1.10_rollup@4.43.0": {
+      "integrity": "sha512-sI93kcJ2cUoMgDRPnrEm0lZhuiDVDqM6ngS/UbHTApIH3+eg3yZM5p/0SDFQQq9Bad0/srFmgBmTdXushzY5kg==",
       "dependencies": [
         "@netlify/blobs",
         "@netlify/dev-utils",
-        "@netlify/serverless-functions-api",
+        "@netlify/serverless-functions-api@1.41.2",
         "@netlify/zip-it-and-ship-it",
         "cron-parser",
         "decache",
@@ -516,27 +505,29 @@
     "@netlify/runtime-utils@1.3.1": {
       "integrity": "sha512-7/vIJlMYrPJPlEW84V2yeRuG3QBu66dmlv9neTmZ5nXzwylhBEOhy11ai+34A8mHCSZI4mKns25w3HM9kaDdJg=="
     },
-    "@netlify/serverless-functions-api@1.41.1": {
-      "integrity": "sha512-swjyZEd8U1QVp01rZdHxpwWie7GkP1kS4+4n8kuNKA8+3G5tD0JXXf3a5d4tdwVvrU9k7a4GP1Bn792UPwecmw=="
+    "@netlify/serverless-functions-api@1.41.2": {
+      "integrity": "sha512-pfCkH50JV06SGMNsNPjn8t17hOcId4fA881HeYQgMBOrewjsw4csaYgHEnCxCEu24Y5x75E2ULbFpqm9CvRCqw=="
     },
-    "@netlify/zip-it-and-ship-it@10.1.1_rollup@4.40.2": {
-      "integrity": "sha512-MMXrty1NADxyMPgd7qZvDUYunhcPhxIA/jWP2joceOoPcAxOno/aS4jFuIHf2Dbb4HdhR+BlvgvDCy7QTXXyLQ==",
+    "@netlify/serverless-functions-api@2.1.1": {
+      "integrity": "sha512-MNYfEmZC6F7ZExOrB/Hrfkif7JW2Cbid9y5poTFEJ6rcAhCLQB8lo0SGlQrFXgKvXowXB14IjpOubaQu2zsyfg=="
+    },
+    "@netlify/zip-it-and-ship-it@12.1.4_rollup@4.43.0": {
+      "integrity": "sha512-/wM1c0iyym/7SlowbgqTuu/+tJS8CDDs4vLhSizKntFl3VOeDVX0kr9qriH9wA2hYstwGSuHsEgEAnKdMcDBOg==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
         "@netlify/binary-info",
-        "@netlify/serverless-functions-api",
-        "@vercel/nft@0.27.7_rollup@4.40.2_acorn@8.14.1",
-        "archiver@5.3.2",
+        "@netlify/serverless-functions-api@2.1.1",
+        "@vercel/nft",
+        "archiver",
         "common-path-prefix",
-        "cp-file",
+        "copy-file",
         "es-module-lexer",
-        "esbuild@0.25.4",
-        "execa@7.2.0",
+        "esbuild",
+        "execa",
         "fast-glob",
         "filter-obj",
-        "find-up@6.3.0",
-        "glob@8.1.0",
+        "find-up",
         "is-builtin-module",
         "is-path-inside",
         "junk",
@@ -684,39 +675,39 @@
         "quansync"
       ]
     },
-    "@rollup/plugin-alias@5.1.1_rollup@4.40.2": {
+    "@rollup/plugin-alias@5.1.1_rollup@4.43.0": {
       "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
       "dependencies": [
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
-    "@rollup/plugin-commonjs@28.0.3_rollup@4.40.2_picomatch@4.0.2": {
+    "@rollup/plugin-commonjs@28.0.3_rollup@4.43.0_picomatch@4.0.2": {
       "integrity": "sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==",
       "dependencies": [
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
         "commondir",
         "estree-walker@2.0.2",
         "fdir",
         "is-reference",
         "magic-string",
         "picomatch@4.0.2",
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
-    "@rollup/plugin-inject@5.0.5_rollup@4.40.2": {
+    "@rollup/plugin-inject@5.0.5_rollup@4.43.0": {
       "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
       "dependencies": [
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
         "estree-walker@2.0.2",
         "magic-string",
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
-    "@rollup/plugin-json@6.1.0_rollup@4.40.2": {
+    "@rollup/plugin-json@6.1.0_rollup@4.43.0": {
       "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
       "dependencies": [
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
-        "rollup@4.40.2"
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
+        "rollup@4.43.0"
       ]
     },
     "@rollup/plugin-node-resolve@15.3.1": {
@@ -729,29 +720,29 @@
         "resolve@1.22.10"
       ]
     },
-    "@rollup/plugin-node-resolve@16.0.1_rollup@4.40.2": {
+    "@rollup/plugin-node-resolve@16.0.1_rollup@4.43.0": {
       "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
       "dependencies": [
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
         "@types/resolve",
         "deepmerge",
         "is-module",
         "resolve@1.22.10",
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
-    "@rollup/plugin-replace@6.0.2_rollup@4.40.2": {
+    "@rollup/plugin-replace@6.0.2_rollup@4.43.0": {
       "integrity": "sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==",
       "dependencies": [
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
         "magic-string",
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
-    "@rollup/plugin-terser@0.4.4_rollup@4.40.2": {
+    "@rollup/plugin-terser@0.4.4_rollup@4.43.0": {
       "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
       "dependencies": [
-        "rollup@4.40.2",
+        "rollup@4.43.0",
         "serialize-javascript",
         "smob",
         "terser"
@@ -766,134 +757,134 @@
         "rollup@4.38.0"
       ]
     },
-    "@rollup/pluginutils@5.1.4_rollup@4.40.2": {
+    "@rollup/pluginutils@5.1.4_rollup@4.43.0": {
       "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
       "dependencies": [
         "@types/estree",
         "estree-walker@2.0.2",
         "picomatch@4.0.2",
-        "rollup@4.40.2"
+        "rollup@4.43.0"
       ]
     },
     "@rollup/rollup-android-arm-eabi@4.38.0": {
       "integrity": "sha512-ldomqc4/jDZu/xpYU+aRxo3V4mGCV9HeTgUBANI3oIQMOL+SsxB+S2lxMpkFp5UamSS3XuTMQVbsS24R4J4Qjg=="
     },
-    "@rollup/rollup-android-arm-eabi@4.40.2": {
-      "integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg=="
+    "@rollup/rollup-android-arm-eabi@4.43.0": {
+      "integrity": "sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw=="
     },
     "@rollup/rollup-android-arm64@4.38.0": {
       "integrity": "sha512-VUsgcy4GhhT7rokwzYQP+aV9XnSLkkhlEJ0St8pbasuWO/vwphhZQxYEKUP3ayeCYLhk6gEtacRpYP/cj3GjyQ=="
     },
-    "@rollup/rollup-android-arm64@4.40.2": {
-      "integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw=="
+    "@rollup/rollup-android-arm64@4.43.0": {
+      "integrity": "sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA=="
     },
     "@rollup/rollup-darwin-arm64@4.38.0": {
       "integrity": "sha512-buA17AYXlW9Rn091sWMq1xGUvWQFOH4N1rqUxGJtEQzhChxWjldGCCup7r/wUnaI6Au8sKXpoh0xg58a7cgcpg=="
     },
-    "@rollup/rollup-darwin-arm64@4.40.2": {
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w=="
+    "@rollup/rollup-darwin-arm64@4.43.0": {
+      "integrity": "sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A=="
     },
     "@rollup/rollup-darwin-x64@4.38.0": {
       "integrity": "sha512-Mgcmc78AjunP1SKXl624vVBOF2bzwNWFPMP4fpOu05vS0amnLcX8gHIge7q/lDAHy3T2HeR0TqrriZDQS2Woeg=="
     },
-    "@rollup/rollup-darwin-x64@4.40.2": {
-      "integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ=="
+    "@rollup/rollup-darwin-x64@4.43.0": {
+      "integrity": "sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg=="
     },
     "@rollup/rollup-freebsd-arm64@4.38.0": {
       "integrity": "sha512-zzJACgjLbQTsscxWqvrEQAEh28hqhebpRz5q/uUd1T7VTwUNZ4VIXQt5hE7ncs0GrF+s7d3S4on4TiXUY8KoQA=="
     },
-    "@rollup/rollup-freebsd-arm64@4.40.2": {
-      "integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ=="
+    "@rollup/rollup-freebsd-arm64@4.43.0": {
+      "integrity": "sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ=="
     },
     "@rollup/rollup-freebsd-x64@4.38.0": {
       "integrity": "sha512-hCY/KAeYMCyDpEE4pTETam0XZS4/5GXzlLgpi5f0IaPExw9kuB+PDTOTLuPtM10TlRG0U9OSmXJ+Wq9J39LvAg=="
     },
-    "@rollup/rollup-freebsd-x64@4.40.2": {
-      "integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q=="
+    "@rollup/rollup-freebsd-x64@4.43.0": {
+      "integrity": "sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg=="
     },
     "@rollup/rollup-linux-arm-gnueabihf@4.38.0": {
       "integrity": "sha512-mimPH43mHl4JdOTD7bUMFhBdrg6f9HzMTOEnzRmXbOZqjijCw8LA5z8uL6LCjxSa67H2xiLFvvO67PT05PRKGg=="
     },
-    "@rollup/rollup-linux-arm-gnueabihf@4.40.2": {
-      "integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q=="
+    "@rollup/rollup-linux-arm-gnueabihf@4.43.0": {
+      "integrity": "sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw=="
     },
     "@rollup/rollup-linux-arm-musleabihf@4.38.0": {
       "integrity": "sha512-tPiJtiOoNuIH8XGG8sWoMMkAMm98PUwlriOFCCbZGc9WCax+GLeVRhmaxjJtz6WxrPKACgrwoZ5ia/uapq3ZVg=="
     },
-    "@rollup/rollup-linux-arm-musleabihf@4.40.2": {
-      "integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg=="
+    "@rollup/rollup-linux-arm-musleabihf@4.43.0": {
+      "integrity": "sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw=="
     },
     "@rollup/rollup-linux-arm64-gnu@4.38.0": {
       "integrity": "sha512-wZco59rIVuB0tjQS0CSHTTUcEde+pXQWugZVxWaQFdQQ1VYub/sTrNdY76D1MKdN2NB48JDuGABP6o6fqos8mA=="
     },
-    "@rollup/rollup-linux-arm64-gnu@4.40.2": {
-      "integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg=="
+    "@rollup/rollup-linux-arm64-gnu@4.43.0": {
+      "integrity": "sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA=="
     },
     "@rollup/rollup-linux-arm64-musl@4.38.0": {
       "integrity": "sha512-fQgqwKmW0REM4LomQ+87PP8w8xvU9LZfeLBKybeli+0yHT7VKILINzFEuggvnV9M3x1Ed4gUBmGUzCo/ikmFbQ=="
     },
-    "@rollup/rollup-linux-arm64-musl@4.40.2": {
-      "integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg=="
+    "@rollup/rollup-linux-arm64-musl@4.43.0": {
+      "integrity": "sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA=="
     },
     "@rollup/rollup-linux-loongarch64-gnu@4.38.0": {
       "integrity": "sha512-hz5oqQLXTB3SbXpfkKHKXLdIp02/w3M+ajp8p4yWOWwQRtHWiEOCKtc9U+YXahrwdk+3qHdFMDWR5k+4dIlddg=="
     },
-    "@rollup/rollup-linux-loongarch64-gnu@4.40.2": {
-      "integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw=="
+    "@rollup/rollup-linux-loongarch64-gnu@4.43.0": {
+      "integrity": "sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg=="
     },
     "@rollup/rollup-linux-powerpc64le-gnu@4.38.0": {
       "integrity": "sha512-NXqygK/dTSibQ+0pzxsL3r4Xl8oPqVoWbZV9niqOnIHV/J92fe65pOir0xjkUZDRSPyFRvu+4YOpJF9BZHQImw=="
     },
-    "@rollup/rollup-linux-powerpc64le-gnu@4.40.2": {
-      "integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q=="
+    "@rollup/rollup-linux-powerpc64le-gnu@4.43.0": {
+      "integrity": "sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw=="
     },
     "@rollup/rollup-linux-riscv64-gnu@4.38.0": {
       "integrity": "sha512-GEAIabR1uFyvf/jW/5jfu8gjM06/4kZ1W+j1nWTSSB3w6moZEBm7iBtzwQ3a1Pxos2F7Gz+58aVEnZHU295QTg=="
     },
-    "@rollup/rollup-linux-riscv64-gnu@4.40.2": {
-      "integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg=="
+    "@rollup/rollup-linux-riscv64-gnu@4.43.0": {
+      "integrity": "sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g=="
     },
     "@rollup/rollup-linux-riscv64-musl@4.38.0": {
       "integrity": "sha512-9EYTX+Gus2EGPbfs+fh7l95wVADtSQyYw4DfSBcYdUEAmP2lqSZY0Y17yX/3m5VKGGJ4UmIH5LHLkMJft3bYoA=="
     },
-    "@rollup/rollup-linux-riscv64-musl@4.40.2": {
-      "integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg=="
+    "@rollup/rollup-linux-riscv64-musl@4.43.0": {
+      "integrity": "sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q=="
     },
     "@rollup/rollup-linux-s390x-gnu@4.38.0": {
       "integrity": "sha512-Mpp6+Z5VhB9VDk7RwZXoG2qMdERm3Jw07RNlXHE0bOnEeX+l7Fy4bg+NxfyN15ruuY3/7Vrbpm75J9QHFqj5+Q=="
     },
-    "@rollup/rollup-linux-s390x-gnu@4.40.2": {
-      "integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ=="
+    "@rollup/rollup-linux-s390x-gnu@4.43.0": {
+      "integrity": "sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw=="
     },
     "@rollup/rollup-linux-x64-gnu@4.38.0": {
       "integrity": "sha512-vPvNgFlZRAgO7rwncMeE0+8c4Hmc+qixnp00/Uv3ht2x7KYrJ6ERVd3/R0nUtlE6/hu7/HiiNHJ/rP6knRFt1w=="
     },
-    "@rollup/rollup-linux-x64-gnu@4.40.2": {
-      "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng=="
+    "@rollup/rollup-linux-x64-gnu@4.43.0": {
+      "integrity": "sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ=="
     },
     "@rollup/rollup-linux-x64-musl@4.38.0": {
       "integrity": "sha512-q5Zv+goWvQUGCaL7fU8NuTw8aydIL/C9abAVGCzRReuj5h30TPx4LumBtAidrVOtXnlB+RZkBtExMsfqkMfb8g=="
     },
-    "@rollup/rollup-linux-x64-musl@4.40.2": {
-      "integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA=="
+    "@rollup/rollup-linux-x64-musl@4.43.0": {
+      "integrity": "sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ=="
     },
     "@rollup/rollup-win32-arm64-msvc@4.38.0": {
       "integrity": "sha512-u/Jbm1BU89Vftqyqbmxdq14nBaQjQX1HhmsdBWqSdGClNaKwhjsg5TpW+5Ibs1mb8Es9wJiMdl86BcmtUVXNZg=="
     },
-    "@rollup/rollup-win32-arm64-msvc@4.40.2": {
-      "integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg=="
+    "@rollup/rollup-win32-arm64-msvc@4.43.0": {
+      "integrity": "sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw=="
     },
     "@rollup/rollup-win32-ia32-msvc@4.38.0": {
       "integrity": "sha512-mqu4PzTrlpNHHbu5qleGvXJoGgHpChBlrBx/mEhTPpnAL1ZAYFlvHD7rLK839LLKQzqEQMFJfGrrOHItN4ZQqA=="
     },
-    "@rollup/rollup-win32-ia32-msvc@4.40.2": {
-      "integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA=="
+    "@rollup/rollup-win32-ia32-msvc@4.43.0": {
+      "integrity": "sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw=="
     },
     "@rollup/rollup-win32-x64-msvc@4.38.0": {
       "integrity": "sha512-jjqy3uWlecfB98Psxb5cD6Fny9Fupv9LrDSPTQZUROqjvZmcCqNu4UMl7qqhlUUGpwiAkotj6GYu4SZdcr/nLw=="
     },
-    "@rollup/rollup-win32-x64-msvc@4.40.2": {
-      "integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="
+    "@rollup/rollup-win32-x64-msvc@4.43.0": {
+      "integrity": "sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw=="
     },
     "@shikijs/core@1.29.2": {
       "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
@@ -943,8 +934,8 @@
     "@shikijs/vscode-textmate@10.0.2": {
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
-    "@sindresorhus/is@7.0.1": {
-      "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ=="
+    "@sindresorhus/is@7.0.2": {
+      "integrity": "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw=="
     },
     "@sindresorhus/merge-streams@2.3.0": {
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
@@ -955,7 +946,7 @@
         "solid-js"
       ]
     },
-    "@solidjs/start@1.1.4_vinxi@0.5.6__@babel+core@7.27.1_seroval@1.3.1_solid-js@1.9.7__seroval@1.3.1": {
+    "@solidjs/start@1.1.4_vinxi@0.5.7__@babel+core@7.27.4_seroval@1.3.1_solid-js@1.9.7__seroval@1.3.1": {
       "integrity": "sha512-ma1TBYqoTju87tkqrHExMReM5Z/+DTXSmi30CCTavtwuR73Bsn4rVGqm528p4sL2koRMfAuBMkrhuttjzhL68g==",
       "dependencies": [
         "@tanstack/server-functions-plugin",
@@ -978,34 +969,32 @@
     "@speed-highlight/core@1.2.7": {
       "integrity": "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="
     },
-    "@tanstack/directive-functions-plugin@1.119.2_@babel+core@7.27.1": {
-      "integrity": "sha512-FsBBDrOQHUA9xCsSgmxJud1NY3PFz8P3LFrz2h+LdyRt/t5jeTvgLRjNZWKMk4izBqyyTYC9X+WF10ZyS9nPMw==",
+    "@tanstack/directive-functions-plugin@1.121.0_vite@6.3.5__picomatch@4.0.2": {
+      "integrity": "sha512-XMLdFvp0OT7sRVlxEPvsqRDn3ufhgmbli7YPrde8quypNJxK0Pwg2AVNTqGGLUZeI81i8CQXTZOXW+GdVXcHBA==",
       "dependencies": [
         "@babel/code-frame@7.26.2",
         "@babel/core",
-        "@babel/plugin-syntax-jsx",
-        "@babel/plugin-syntax-typescript",
-        "@babel/template",
         "@babel/traverse",
         "@babel/types",
         "@tanstack/router-utils",
         "babel-dead-code-elimination",
-        "dedent",
         "tiny-invariant",
-        "vite@6.1.4"
+        "vite"
       ]
     },
-    "@tanstack/router-utils@1.115.0": {
-      "integrity": "sha512-Dng4y+uLR9b5zPGg7dHReHOTHQa6x+G6nCoZshsDtWrYsrdCcJEtLyhwZ5wG8OyYS6dVr/Cn+E5Bd2b6BhJ89w==",
+    "@tanstack/router-utils@1.121.0_@babel+core@7.27.4": {
+      "integrity": "sha512-+gOHZdEVjOTTdk8Z7J/NVG0KdvzxFeUYjINYZEqQDRKoxEg8f+Npram0MXGy8N15OyZrsm+KHR1vMFZ2yEvZkw==",
       "dependencies": [
+        "@babel/core",
         "@babel/generator",
         "@babel/parser",
+        "@babel/preset-typescript",
         "ansis",
         "diff"
       ]
     },
-    "@tanstack/server-functions-plugin@1.119.2_@babel+core@7.27.1": {
-      "integrity": "sha512-ramMedB4yt+fhFHio3GqRLUQVwKBEBREnHEVetHEYHLe6h+qYEwaVxQrQ75J+dTTWXa14DLadtgR3ygEydtfqA==",
+    "@tanstack/server-functions-plugin@1.121.0_@babel+core@7.27.4": {
+      "integrity": "sha512-gz3Mpn4t1cB3ZJLaeTJ6GS2wpAis24qJHvqyFQrTKjRiz8LOHqsGDOnT5vgA5Vdjlv3alZiyhPW7WFFctsI/VA==",
       "dependencies": [
         "@babel/code-frame@7.26.2",
         "@babel/core",
@@ -1016,7 +1005,6 @@
         "@babel/types",
         "@tanstack/directive-functions-plugin",
         "babel-dead-code-elimination",
-        "dedent",
         "tiny-invariant"
       ]
     },
@@ -1073,10 +1061,10 @@
         "@types/braces"
       ]
     },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dependencies": [
-        "undici-types@6.19.8"
+        "undici-types@6.20.0"
       ]
     },
     "@types/normalize-package-data@2.4.4": {
@@ -1097,23 +1085,42 @@
         "@types/node"
       ]
     },
-    "@typescript-eslint/types@5.62.0": {
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ=="
-    },
-    "@typescript-eslint/typescript-estree@5.62.0_typescript@5.8.3": {
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+    "@typescript-eslint/project-service@8.34.0_typescript@5.8.3": {
+      "integrity": "sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==",
       "dependencies": [
+        "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
-        "@typescript-eslint/visitor-keys",
-        "debug@4.4.0",
-        "globby@11.1.0",
-        "is-glob",
-        "semver@7.7.2",
-        "tsutils"
+        "debug@4.4.1",
+        "typescript"
       ]
     },
-    "@typescript-eslint/visitor-keys@5.62.0": {
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+    "@typescript-eslint/tsconfig-utils@8.34.0_typescript@5.8.3": {
+      "integrity": "sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==",
+      "dependencies": [
+        "typescript"
+      ]
+    },
+    "@typescript-eslint/types@8.34.0": {
+      "integrity": "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="
+    },
+    "@typescript-eslint/typescript-estree@8.34.0_typescript@5.8.3": {
+      "integrity": "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==",
+      "dependencies": [
+        "@typescript-eslint/project-service",
+        "@typescript-eslint/tsconfig-utils",
+        "@typescript-eslint/types",
+        "@typescript-eslint/visitor-keys",
+        "debug@4.4.1",
+        "fast-glob",
+        "is-glob",
+        "minimatch@9.0.5",
+        "semver@7.7.2",
+        "ts-api-utils",
+        "typescript"
+      ]
+    },
+    "@typescript-eslint/visitor-keys@8.34.0": {
+      "integrity": "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==",
       "dependencies": [
         "@typescript-eslint/types",
         "eslint-visitor-keys"
@@ -1122,20 +1129,20 @@
     "@ungap/structured-clone@1.3.0": {
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
-    "@unocss/astro@66.1.3": {
-      "integrity": "sha512-jsubeNZE/LThm8fXPMWNmNXmG5KsM4LIpJ37rq5tgP6RqX0UwLvA4t9yXNJdr6aLDJN6+KpQXfGhIrf/Aj7YIQ==",
+    "@unocss/astro@66.2.0": {
+      "integrity": "sha512-UL95urnTaAtdu4WfRRuD52vziULkatco+Mdmza6FWhMnMaCvj5ErY1VDJQRCyO5foEYT4ky8pbzs5gv6ZGU40A==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/reset",
         "@unocss/vite"
       ]
     },
-    "@unocss/cli@66.1.3": {
-      "integrity": "sha512-7Uw6VDsk7w6E6PkrRfq34d+tJpTcNWfksNkLorpQhwwlpbIod69iNHj5gn5u0SJwrAAuFvGNTQzOWQar8HlKCQ==",
+    "@unocss/cli@66.2.0": {
+      "integrity": "sha512-8yV4YuDFuuw9uizj9ic62f8AVqINz5zAaNFMi9SbfkAhDwHCIuozTQEgaQ80sH3M8wPc+lsZHi+HTbsvRXdFaA==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/preset-uno",
         "cac",
         "chokidar@3.6.0",
@@ -1148,29 +1155,29 @@
         "unplugin-utils"
       ]
     },
-    "@unocss/config@66.1.3": {
-      "integrity": "sha512-oEKomMMY+f6+4HkU538XG7jOJZAMMk2WczT2XS6HdpJWwUzSKHlhs9R2pj7g0HLJZsROzP1A1+OBstHcQLe94A==",
+    "@unocss/config@66.2.0": {
+      "integrity": "sha512-vJM00OU1FG/sZ4+uTO20e3ASRuUzlKkihwfd8BPTFDamkdbYehl7wZO1DI1TxtQv+bIc4Ociox6EKKCeQVJ/mA==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "unconfig"
       ]
     },
     "@unocss/core@0.65.4": {
       "integrity": "sha512-a2JOoFutrhqd5RgPhIR5FIXrDoHDU3gwCbPrpT6KYTjsqlSc/fv02yZ+JGOZFN3MCFhCmaPTs+idDFtwb3xU8g=="
     },
-    "@unocss/core@66.1.3": {
-      "integrity": "sha512-qV88JvRvSMgMo1FMWZfNiKYy+IvaXswyMMyZvuQxCrNkDPtij46pu7G3heKdLl7mNTdSgF0+LQPEqVYVA27pCA=="
+    "@unocss/core@66.2.0": {
+      "integrity": "sha512-jq+UPvmf271MjY/RoREBmjSCzTYdjzdlgBcjmtymYjBRg7a6a0GiSuhdL0D20cwQ4MoBvlO1tIzgCqnqImACBg=="
     },
-    "@unocss/extractor-arbitrary-variants@66.1.3": {
-      "integrity": "sha512-4nlQKx40ch+4hjNlN/jWZDd06qbXFj5xwMpnNjDcb008zgCuPK2dEmg/eDddSv25KZh9W+3fvwduMDNK6YDooQ==",
+    "@unocss/extractor-arbitrary-variants@66.2.0": {
+      "integrity": "sha512-tRvWLbLLZweCv+eujbkvjflNclbkrJHhW2asuBUcaHXCzXIHCYgbBdF3lV5ww1lBBfEUWekgyFC/9fbB4rh1fg==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/inspector@66.1.3": {
-      "integrity": "sha512-ntKtc9ZJBrYf6BFZlwfWwDCWKvZQd3A3W4i0NGdHXlzAC3CFGf19U355e49DfKCln6zDtTVHTPWCuMzMH2H52Q==",
+    "@unocss/inspector@66.2.0": {
+      "integrity": "sha512-pks1xo8A33IUun9imnZasjsqyocKEYsy+KJHXZjvx+ikD1Lnwfnym7plHdn6wvKry7bjF1H+Pm8mBtawDLaOTA==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/rule-utils",
         "colorette",
         "gzip-size@6.0.0",
@@ -1178,169 +1185,152 @@
         "vue-flow-layout"
       ]
     },
-    "@unocss/postcss@66.1.3_postcss@8.5.3": {
-      "integrity": "sha512-kVJlJ19WnG0Ec4BpdJUcUaA/B5md440WiKId2oaD6nzT6IDozpbQ3DwW2HtQ33YyagkmwYgocb0oodEm2lGilA==",
+    "@unocss/postcss@66.2.0_postcss@8.5.3": {
+      "integrity": "sha512-GBBP/gcDVpu+kjh3PvurhWwB670ei69bxWU40/cxAcgmLbl4EdG5g1FmlI2FaK/e1DhDf/+3v4dFmzy/Tz6pow==",
       "dependencies": [
         "@unocss/config",
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/rule-utils",
         "css-tree",
         "postcss",
         "tinyglobby"
       ]
     },
-    "@unocss/preset-attributify@66.1.3": {
-      "integrity": "sha512-geEaGxs7j85P1HirbAlIRnCrJwxjvvbUQDC2TOXUZ67So1co2mac/3uo0QMJsdry14iSIIfu6rNVaDjMSC4K5g==",
+    "@unocss/preset-attributify@66.2.0": {
+      "integrity": "sha512-O1ZK5spw/tgcwACEcurw/BR6C594vh1hnAuEWnIoSH+3b2WBCpSORC7uF+UyW4Z5zvGz4asU3G27CGzuzIM31A==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/preset-icons@66.1.3": {
-      "integrity": "sha512-n1y8I4cVfOOldgyuncwtMn8/wMVzUzVvwdgQk2ow/D07TBgsyZZfk98N1AAFrS772SRr8+YmJ5im4+bNLZaYdA==",
+    "@unocss/preset-icons@66.2.0": {
+      "integrity": "sha512-MpANsJ4hpEfII180i23Tl+Sf0yNVa6lusfQglhjNYFMJwUIobiwMD2zehDLHwcBW31IwbjAXSYW0xs2xzemUkA==",
       "dependencies": [
         "@iconify/utils",
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "ofetch"
       ]
     },
-    "@unocss/preset-mini@66.1.3": {
-      "integrity": "sha512-8HYCTl0YK5FGzfVbtshN1MIQfNZy8baT4BLdcDb2qtsLjG5qP7rmqTdk3c8OpoKhGLUuXPXBaDjh+D5TAMBY3w==",
+    "@unocss/preset-mini@66.2.0": {
+      "integrity": "sha512-ESOinBvDeCVKFvS1goI1+sp9tgasO0WSQmwaB+G+GK9uA8LMMMuslOjha3gUUVCskY9V+e5pVmZEJ6YmA72bJQ==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-tagify@66.1.3": {
-      "integrity": "sha512-IUhggch3uaDraTgnomjo9eRIsarI3r3Wy5Cyu5GtmAIs4RIe7MTVsGeL21q7qgC12/UmQ7E9zdyJR1IbQ6L9aQ==",
+    "@unocss/preset-tagify@66.2.0": {
+      "integrity": "sha512-x1kqtcbMsLCvM9MpjXt8nsEA17Y3HIXbGpe88iXTPDu1b+cxgprSKbMTQRWvzZgBansCN6XpB+9/QJK1UtvLiA==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/preset-typography@66.1.3": {
-      "integrity": "sha512-97n8xIYwQlxhor0FiLsmp697G6DTmUauFNv1trJf2d2wBP2W/AAkIbKw0t8SEN06eduvB7Epq7h7502dyULV4A==",
+    "@unocss/preset-typography@66.2.0": {
+      "integrity": "sha512-27vlixFSjdF6SHodFhqIiXXmMxk11UXAFML+yHc/6jW01hpUnaFlwns+Jg47bLlVVvjLuVlTkgGr6oRftDA29g==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-uno@66.1.3": {
-      "integrity": "sha512-JM/6cMGX3xSdU2a+S0JOl3aEWlQoOv0J3yyyQgd0lamkWF3RhRON6QZwhcMaLGVAPwVrSfaLG2ucCH9uubGpdg==",
+    "@unocss/preset-uno@66.2.0": {
+      "integrity": "sha512-8tkDSrjZm4FIm7SxtmD9BEvQ0QxDO4jerV32LfvlhZCHeSypZGNGWWQROJdEpgOOz9axOuWibn/r4klidEAATw==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/preset-web-fonts@66.1.3": {
-      "integrity": "sha512-uOWEmru+tbr/gttM6X/sJHoY0TCVdUx8/EiVITrLe51Agi2UECQlCdBH2lZNnfc3RCArCn4JevMLHd1btHRzJg==",
+    "@unocss/preset-web-fonts@66.2.0": {
+      "integrity": "sha512-6uJRmbooDmZOBw/vKj4vghqguTXGBmJYtHbJjmTZ1dW3322l38w1RVU1hWrFJf/xSFyMv5ir38dSwSS7gygrwQ==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "ofetch"
       ]
     },
-    "@unocss/preset-wind3@66.1.3": {
-      "integrity": "sha512-oFQKA/v0EbCtZaxTBKvTfyVG1hcDJ1CXQ7gsghynMpOKMJbnb7bq4NEuDoMdHCVV9yKEQaSXkbbyHpeithBO3g==",
+    "@unocss/preset-wind3@66.2.0": {
+      "integrity": "sha512-87o52P0y3g7Xq9iya/QO7lij6CI6FfM/wu6ivTwLEdio+SSC8m8QcDYFakGprUvFY4GdYk+Hv4WXYu6f3EV+zw==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind4@66.1.3": {
-      "integrity": "sha512-QwPDtQv/Asz1sYT0HcXPROolKwDCCcHqp0kkrO7aOGaVqyTF6ByfT+7cfI+Mv9uKtZejd+kQTUM/1ag8mzj3UA==",
+    "@unocss/preset-wind4@66.2.0": {
+      "integrity": "sha512-+qllvO142kajxD9EFag1WmiCJOjIxoMTVh1sW30SFXftB6rvVCaA8GbDo/Jnk9gXtmRQ2L9ZnuxPIx8W65pBjA==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind@66.1.3": {
-      "integrity": "sha512-PA+W1n3b7vXYAp3bD5BoSXVHDVhXPXOpKkEYDhMHL8+z567/dwDVrkZ5vAPsu1s4bW1PLqN/enzKso74TOfDCg==",
+    "@unocss/preset-wind@66.2.0": {
+      "integrity": "sha512-04h1WPRoAli+XQX9g+k4ryFTTcWiFuF0LQX83Py7DNbTYRKFtTaNqLWQrZcORsEV8azo/VztMxygloqxJhUmfg==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/reset@66.1.3": {
-      "integrity": "sha512-tc8uSka0R0zlfJfOjoLUg0NMT4RQnAe6nyelBXE86qYQaNV2YD7tf2iEWMmbjNwmiIjc8MigHAvYt1HmdirNww=="
+    "@unocss/reset@66.2.0": {
+      "integrity": "sha512-lANXvmU81Cmx5wo4Bwuw9VhOdOFzo/I2L0RCHSmH22m6+VQwG+ho9YONygf6AcN/ookyXX2F7si3CPM6Hkf4Cw=="
     },
-    "@unocss/rule-utils@66.1.3": {
-      "integrity": "sha512-EP8QRcOO/dAD1+RxOnWOiGaIyo4IJQOdqD0nBteZDoL3X9vj6GPUI5yo8f7uR6k0koI/hxJv5BVsfQZSIsVjLA==",
+    "@unocss/rule-utils@66.2.0": {
+      "integrity": "sha512-T2Gg8WwLeCi7QaOss6EKC5Ypmbls+dqet5sMRsiIE5Mi04j3ndS0+lTwV/x7X6NnN6kCoh0IlwCdBUU4tkJbkQ==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "magic-string"
       ]
     },
-    "@unocss/transformer-attributify-jsx@66.1.3": {
-      "integrity": "sha512-9dSacVrxmjiJUDRjK4f7qHcI//MjiApopRWtRrnyFbAzsKTqXHxstVCqYKkzCGRt2JcW01MXd/uL7q0Dw/YSCQ==",
+    "@unocss/transformer-attributify-jsx@66.2.0": {
+      "integrity": "sha512-qtJJ8KCPRRdsjvTvfz71MMjAD3WAZVPBDjewOtw2OSJDSkrjHf9SiBXlxpo11nNTADscJw6RsVfVaU1drgnQbg==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/transformer-compile-class@66.1.3": {
-      "integrity": "sha512-cV3qVDvuTM1DXBE9hyP69UU/etrloFrOx93ztjhuznKfCDyjWI79oL95BxSyHfD0bPNWKH9wSqNgesgnQKhkog==",
+    "@unocss/transformer-compile-class@66.2.0": {
+      "integrity": "sha512-fQ4ma/JKgzmQp20IksCCirNNMcwgSE6JS54glwactEdgTTCsedfigAbjaqnX0wGYkqI8Q8mRb06sT8+dCwbjfA==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/transformer-directives@66.1.3": {
-      "integrity": "sha512-xo91rCu6o5NEbc9EJrEQA1mKRVVwpstm78vIqKJAhU57QlR7Mj4UDbq46ogkt+jcljKCHppp+9aQXRk/Z4PAZw==",
+    "@unocss/transformer-directives@66.2.0": {
+      "integrity": "sha512-FHhcXJFyzlzIGE9gDo3jSQZ1E25xhWGjwWmOtX7bt2s8QBNg3HjKlYHUrj9TRR0ksV3YENLk0WP3VzOnLBUFdg==",
       "dependencies": [
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/rule-utils",
         "css-tree"
       ]
     },
-    "@unocss/transformer-variant-group@66.1.3": {
-      "integrity": "sha512-FCB5LB459FTE/E/OXn5g6O/o7AOJbiEDRiA/WXtalB/VLsqc5DHSbb9isITYUTh+PqzZZef8W6+kQjG5wx5yNA==",
+    "@unocss/transformer-variant-group@66.2.0": {
+      "integrity": "sha512-mgmvDlBpeZ/hblbwE3jGRK8RpoDgrllFARR2+g3tvGw9ZM2BA+RAgMz307s9th1F+PCrDHCG1R+dCLN1b1qyww==",
       "dependencies": [
-        "@unocss/core@66.1.3"
+        "@unocss/core@66.2.0"
       ]
     },
-    "@unocss/vite@66.1.3_vite@6.3.5__picomatch@4.0.2": {
-      "integrity": "sha512-DBehjzx93XkWK6skudKZ9BewcFoZdbVhn+7tSM00HoDjQ8WHeC22saJf0UY9sAkdq7f2k2enAhAcznr2/DUTng==",
+    "@unocss/vite@66.2.0_vite@6.3.5__picomatch@4.0.2": {
+      "integrity": "sha512-nWEH0Ym/161nu66T1ANIjmsh5quGOINaunTqUnb41j1U5Y6StW35JmiH3d4Gpk5IsNJ8plBIEaUADxoBIPZZMw==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/inspector",
         "chokidar@3.6.0",
         "magic-string",
         "pathe@2.0.3",
         "tinyglobby",
         "unplugin-utils",
-        "vite@6.3.5_picomatch@4.0.2"
+        "vite"
       ]
     },
-    "@vercel/nft@0.27.7_rollup@4.40.2_acorn@8.14.1": {
-      "integrity": "sha512-FG6H5YkP4bdw9Ll1qhmbxuE8KwW2E/g8fJpM183fWQLeVDGqzeywMIeJ9h2txdWZ03psgWMn6QymTxaDLmdwUg==",
+    "@vercel/nft@0.29.4_rollup@4.43.0_acorn@8.15.0": {
+      "integrity": "sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==",
       "dependencies": [
-        "@mapbox/node-pre-gyp@1.0.11",
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
+        "@mapbox/node-pre-gyp",
+        "@rollup/pluginutils@5.1.4_rollup@4.43.0",
         "acorn",
         "acorn-import-attributes",
         "async-sema",
         "bindings",
         "estree-walker@2.0.2",
-        "glob@7.2.3",
-        "graceful-fs",
-        "micromatch",
-        "node-gyp-build",
-        "resolve-from"
-      ]
-    },
-    "@vercel/nft@0.29.3_rollup@4.40.2_acorn@8.14.1": {
-      "integrity": "sha512-aVV0E6vJpuvImiMwU1/5QKkw2N96BRFE7mBYGS7FhXUoS6V7SarQ+8tuj33o7ofECz8JtHpmQ9JW+oVzOoB7MA==",
-      "dependencies": [
-        "@mapbox/node-pre-gyp@2.0.0",
-        "@rollup/pluginutils@5.1.4_rollup@4.40.2",
-        "acorn",
-        "acorn-import-attributes",
-        "async-sema",
-        "bindings",
-        "estree-walker@2.0.2",
-        "glob@10.4.5",
+        "glob",
         "graceful-fs",
         "node-gyp-build",
         "picomatch@4.0.2",
@@ -1357,19 +1347,19 @@
         "consola",
         "defu",
         "get-port-please",
-        "h3@1.15.2",
+        "h3",
         "http-shutdown",
         "jiti@1.21.7",
         "mlly",
         "node-forge",
         "pathe@1.1.2",
         "std-env",
-        "ufo@1.6.1",
+        "ufo",
         "untun",
         "uqr"
       ]
     },
-    "@vinxi/plugin-directives@0.5.1_vinxi@0.5.6__@babel+core@7.27.1_acorn@8.14.1": {
+    "@vinxi/plugin-directives@0.5.1_vinxi@0.5.7__@babel+core@7.27.4_acorn@8.15.0": {
       "integrity": "sha512-pH/KIVBvBt7z7cXrUH/9uaqcdxjegFC7+zvkZkdOyWzs+kQD5KPf3cl8kC+5ayzXHT+OMlhGhyitytqN3cGmHg==",
       "dependencies": [
         "@babel/parser",
@@ -1380,11 +1370,11 @@
         "astring",
         "magicast@0.2.11",
         "recast",
-        "tslib@2.8.1",
+        "tslib",
         "vinxi"
       ]
     },
-    "@vinxi/server-components@0.5.1_vinxi@0.5.6__@babel+core@7.27.1_acorn@8.14.1": {
+    "@vinxi/server-components@0.5.1_vinxi@0.5.7__@babel+core@7.27.4_acorn@8.15.0": {
       "integrity": "sha512-0BsG95qac3dkhfdRZxqzqYWJE4NvPL7ILlV43B6K6ho1etXWB2e5b0IxsUAUbyqpqiXM7mSRivojuXjb2G4OsQ==",
       "dependencies": [
         "@vinxi/plugin-directives",
@@ -1479,29 +1469,29 @@
       "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
       "dependencies": [
         "@whatwg-node/promise-helpers",
-        "tslib@2.8.1"
+        "tslib"
       ]
     },
-    "@whatwg-node/fetch@0.10.7": {
-      "integrity": "sha512-sL31zX8BqZovZc38ovBFmKEfao9AzZ/24sWSHKNhDhcnzIO/PYAX2xF6vYtgU9hinrEGlvScTTyKSMynHGdfEA==",
+    "@whatwg-node/fetch@0.10.8": {
+      "integrity": "sha512-Rw9z3ctmeEj8QIB9MavkNJqekiu9usBCSMZa+uuAvM0lF3v70oQVCXNppMIqaV6OTZbdaHF1M2HLow58DEw+wg==",
       "dependencies": [
         "@whatwg-node/node-fetch",
         "urlpattern-polyfill@10.1.0"
       ]
     },
-    "@whatwg-node/node-fetch@0.7.19": {
-      "integrity": "sha512-ippPt75epj7Tg6H5znI9lBBQ4gi+x23QsIF7UN1Z02MUqzhbkjhGsUtNnYGS3osrqvyKtbGKmEya6IqIPRmtdw==",
+    "@whatwg-node/node-fetch@0.7.21": {
+      "integrity": "sha512-QC16IdsEyIW7kZd77aodrMO7zAoDyyqRCTLg+qG4wqtP4JV9AA+p7/lgqMdD29XyiYdVvIdFrfI9yh7B1QvRvw==",
       "dependencies": [
         "@fastify/busboy",
         "@whatwg-node/disposablestack",
         "@whatwg-node/promise-helpers",
-        "tslib@2.8.1"
+        "tslib"
       ]
     },
     "@whatwg-node/promise-helpers@1.3.2": {
       "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
       "dependencies": [
-        "tslib@2.8.1"
+        "tslib"
       ]
     },
     "@whatwg-node/server@0.9.71": {
@@ -1510,11 +1500,8 @@
         "@whatwg-node/disposablestack",
         "@whatwg-node/fetch",
         "@whatwg-node/promise-helpers",
-        "tslib@2.8.1"
+        "tslib"
       ]
-    },
-    "abbrev@1.1.1": {
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abbrev@3.0.1": {
       "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="
@@ -1525,38 +1512,32 @@
         "event-target-shim"
       ]
     },
-    "acorn-import-attributes@1.9.5_acorn@8.14.1": {
+    "acorn-import-attributes@1.9.5_acorn@8.15.0": {
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dependencies": [
         "acorn"
       ]
     },
-    "acorn-jsx@5.3.2_acorn@8.14.1": {
+    "acorn-jsx@5.3.2_acorn@8.15.0": {
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dependencies": [
         "acorn"
       ]
     },
-    "acorn-loose@8.5.0": {
-      "integrity": "sha512-ppga7pybjwX2HSJv5ayHe6QG4wmNS1RQ2wjBMFTVnOj0h8Rxsmtc6fnVzINqHSSRz23sTe9IL3UAt/PU9gc4FA==",
+    "acorn-loose@8.5.1": {
+      "integrity": "sha512-H68u/wiI8PAsSBclEIWwUg3dqEaDZXQHCovulbedgp78zJstjn7gDjfGgwUtW0BHi+KasryFLreHAGX/iXU85A==",
       "dependencies": [
         "acorn"
       ]
     },
-    "acorn-typescript@1.4.13_acorn@8.14.1": {
+    "acorn-typescript@1.4.13_acorn@8.15.0": {
       "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
       "dependencies": [
         "acorn"
       ]
     },
-    "acorn@8.14.1": {
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
-    },
-    "agent-base@6.0.2": {
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": [
-        "debug@4.4.0"
-      ]
+    "acorn@8.15.0": {
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "agent-base@7.1.3": {
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
@@ -1582,8 +1563,8 @@
     "ansi-styles@6.2.1": {
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
     },
-    "ansis@3.17.0": {
-      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg=="
+    "ansis@4.1.0": {
+      "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="
     },
     "anymatch@3.1.3": {
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
@@ -1592,43 +1573,10 @@
         "picomatch@2.3.1"
       ]
     },
-    "aproba@2.0.0": {
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
-    },
-    "archiver-utils@2.1.0": {
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dependencies": [
-        "glob@7.2.3",
-        "graceful-fs",
-        "lazystream",
-        "lodash.defaults",
-        "lodash.difference",
-        "lodash.flatten",
-        "lodash.isplainobject",
-        "lodash.union",
-        "normalize-path@3.0.0",
-        "readable-stream@2.3.8"
-      ]
-    },
-    "archiver-utils@3.0.4": {
-      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
-      "dependencies": [
-        "glob@7.2.3",
-        "graceful-fs",
-        "lazystream",
-        "lodash.defaults",
-        "lodash.difference",
-        "lodash.flatten",
-        "lodash.isplainobject",
-        "lodash.union",
-        "normalize-path@3.0.0",
-        "readable-stream@3.6.2"
-      ]
-    },
     "archiver-utils@5.0.2": {
       "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
       "dependencies": [
-        "glob@10.4.5",
+        "glob",
         "graceful-fs",
         "is-stream@2.0.1",
         "lazystream",
@@ -1637,47 +1585,25 @@
         "readable-stream@4.7.0"
       ]
     },
-    "archiver@5.3.2": {
-      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
-      "dependencies": [
-        "archiver-utils@2.1.0",
-        "async",
-        "buffer-crc32@0.2.13",
-        "readable-stream@3.6.2",
-        "readdir-glob",
-        "tar-stream@2.2.0",
-        "zip-stream@4.1.1"
-      ]
-    },
     "archiver@7.0.1": {
       "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
       "dependencies": [
-        "archiver-utils@5.0.2",
+        "archiver-utils",
         "async",
         "buffer-crc32@1.0.0",
         "readable-stream@4.7.0",
         "readdir-glob",
-        "tar-stream@3.1.7",
-        "zip-stream@6.0.1"
+        "tar-stream",
+        "zip-stream"
       ]
     },
-    "are-we-there-yet@2.0.0": {
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "dependencies": [
-        "delegates",
-        "readable-stream@3.6.2"
-      ]
-    },
-    "array-union@2.1.0": {
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-    },
-    "ast-module-types@5.0.0": {
-      "integrity": "sha512-JvqziE0Wc0rXQfma0HZC/aY7URXHFuZV84fJRtP8u+lhp0JYCNd5wJzVXP45t0PH0Mej3ynlzvdyITYIu0G4LQ=="
+    "ast-module-types@6.0.1": {
+      "integrity": "sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA=="
     },
     "ast-types@0.16.1": {
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dependencies": [
-        "tslib@2.8.1"
+        "tslib"
       ]
     },
     "astring@1.9.0": {
@@ -1701,7 +1627,7 @@
         "@babel/types"
       ]
     },
-    "babel-plugin-jsx-dom-expressions@0.39.8_@babel+core@7.27.1": {
+    "babel-plugin-jsx-dom-expressions@0.39.8_@babel+core@7.27.4": {
       "integrity": "sha512-/MVOIIjonylDXnrWmG23ZX82m9mtKATsVHB7zYlPfDR9Vdd/NBE48if+wv27bSkBtyO7EPMUlcUc4J63QwuACQ==",
       "dependencies": [
         "@babel/core",
@@ -1713,7 +1639,7 @@
         "validate-html-nesting"
       ]
     },
-    "babel-preset-solid@1.9.6_@babel+core@7.27.1": {
+    "babel-preset-solid@1.9.6_@babel+core@7.27.4": {
       "integrity": "sha512-HXTK9f93QxoH8dYn1M2mJdOlWgMsR88Lg/ul6QCZGkNTktjTE5HAf93YxQumHoCudLEtZrU1cFCMFOVho6GqFg==",
       "dependencies": [
         "@babel/core",
@@ -1738,14 +1664,6 @@
         "file-uri-to-path"
       ]
     },
-    "bl@4.1.0": {
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": [
-        "buffer@5.7.1",
-        "inherits",
-        "readable-stream@3.6.2"
-      ]
-    },
     "boxen@8.0.1": {
       "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
       "dependencies": [
@@ -1759,15 +1677,8 @@
         "wrap-ansi@9.0.0"
       ]
     },
-    "brace-expansion@1.1.11": {
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": [
-        "balanced-match",
-        "concat-map"
-      ]
-    },
-    "brace-expansion@2.0.1": {
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "brace-expansion@2.0.2": {
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": [
         "balanced-match"
       ]
@@ -1778,8 +1689,8 @@
         "fill-range"
       ]
     },
-    "browserslist@4.24.5": {
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+    "browserslist@4.25.0": {
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dependencies": [
         "caniuse-lite",
         "electron-to-chromium",
@@ -1796,13 +1707,6 @@
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "buffer@5.7.1": {
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dependencies": [
-        "base64-js",
-        "ieee754"
-      ]
-    },
     "buffer@6.0.3": {
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dependencies": [
@@ -1813,14 +1717,14 @@
     "builtin-modules@3.3.0": {
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
     },
-    "c12@3.0.3_magicast@0.3.5": {
-      "integrity": "sha512-uC3MacKBb0Z15o5QWCHvHWj5Zv34pGQj9P+iXKSpTuSGFS0KKhUWf4t9AJ+gWjYOdmWCPEGpEzm8sS0iqbpo1w==",
+    "c12@3.0.4_magicast@0.3.5": {
+      "integrity": "sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==",
       "dependencies": [
         "chokidar@4.0.3",
         "confbox@0.2.2",
         "defu",
         "dotenv",
-        "exsolve@1.0.5",
+        "exsolve",
         "giget",
         "jiti@2.4.2",
         "magicast@0.3.5",
@@ -1854,8 +1758,8 @@
     "camelcase@8.0.0": {
       "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="
     },
-    "caniuse-lite@1.0.30001718": {
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw=="
+    "caniuse-lite@1.0.30001722": {
+      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA=="
     },
     "ccount@2.0.1": {
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
@@ -1888,9 +1792,6 @@
         "readdirp@4.1.2"
       ]
     },
-    "chownr@2.0.0": {
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-    },
     "chownr@3.0.0": {
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="
     },
@@ -1906,7 +1807,7 @@
     "clipboardy@4.0.0": {
       "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
       "dependencies": [
-        "execa@8.0.1",
+        "execa",
         "is-wsl@3.1.0",
         "is64bit"
       ]
@@ -1947,9 +1848,6 @@
         "simple-swizzle"
       ]
     },
-    "color-support@1.1.3": {
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-    },
     "color@3.2.1": {
       "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
       "dependencies": [
@@ -1973,6 +1871,9 @@
     "commander@10.0.1": {
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
+    "commander@12.1.0": {
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
+    },
     "commander@2.20.3": {
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
@@ -1985,42 +1886,24 @@
     "compatx@0.2.0": {
       "integrity": "sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA=="
     },
-    "compress-commons@4.1.2": {
-      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
-      "dependencies": [
-        "buffer-crc32@0.2.13",
-        "crc32-stream@4.0.3",
-        "normalize-path@3.0.0",
-        "readable-stream@3.6.2"
-      ]
-    },
     "compress-commons@6.0.2": {
       "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
       "dependencies": [
         "crc-32",
-        "crc32-stream@6.0.0",
+        "crc32-stream",
         "is-stream@2.0.1",
         "normalize-path@3.0.0",
         "readable-stream@4.7.0"
       ]
     },
-    "concat-map@0.0.1": {
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
     "confbox@0.1.8": {
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
-    },
-    "confbox@0.2.1": {
-      "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg=="
     },
     "confbox@0.2.2": {
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="
     },
     "consola@3.4.2": {
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
-    },
-    "console-control-strings@1.1.0": {
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
@@ -2034,26 +1917,18 @@
     "cookie@1.0.2": {
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
     },
-    "core-util-is@1.0.3": {
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "cp-file@10.0.0": {
-      "integrity": "sha512-vy2Vi1r2epK5WqxOLnskeKeZkdZvTKfFZQCplE3XWsP+SUJyd5XAUFC9lFgTjjXJF2GMne/UML14iEmkAaDfFg==",
+    "copy-file@11.0.0": {
+      "integrity": "sha512-mFsNh/DIANLqFt5VHZoGirdg7bK5+oTWlhnGu6tgRhzBlnEKWaPX2xrFaLltii/6rmhqFMJqffUgknuRdpYlHw==",
       "dependencies": [
         "graceful-fs",
-        "nested-error-stacks",
         "p-event"
       ]
     },
+    "core-util-is@1.0.3": {
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "crc-32@1.2.2": {
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
-    },
-    "crc32-stream@4.0.3": {
-      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
-      "dependencies": [
-        "crc-32",
-        "readable-stream@3.6.2"
-      ]
     },
     "crc32-stream@6.0.0": {
       "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
@@ -2098,8 +1973,8 @@
     "data-uri-to-buffer@4.0.1": {
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
-    "dax-sh@0.43.1": {
-      "integrity": "sha512-KmH0fgGVtJDjXTcltFVkU+fkwuCjIFhrC9E2Z7Sc6Ug/mR9ubXGXhXHdPeGsGQnIkthINF2dFcbeGEbD/9g9Hg==",
+    "dax-sh@0.43.2": {
+      "integrity": "sha512-uULa1sSIHgXKGCqJ/pA0zsnzbHlVnuq7g8O2fkHokWFNwEGIhh5lAJlxZa1POG5En5ba7AU4KcBAvGQWMMf8rg==",
       "dependencies": [
         "@deno/shim-deno",
         "undici-types@5.28.4"
@@ -2114,8 +1989,8 @@
         "ms@2.0.0"
       ]
     },
-    "debug@4.4.0": {
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dependencies": [
         "ms@2.1.3"
       ]
@@ -2126,9 +2001,6 @@
         "callsite"
       ]
     },
-    "dedent@1.6.0": {
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA=="
-    },
     "deepmerge@4.3.1": {
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
@@ -2138,9 +2010,6 @@
     "defu@6.1.4": {
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
-    "delegates@1.0.0": {
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
     "denque@2.1.0": {
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
@@ -2149,9 +2018,6 @@
     },
     "dequal@2.0.3": {
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    },
-    "destr@2.0.3": {
-      "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
     },
     "destr@2.0.5": {
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
@@ -2165,8 +2031,8 @@
     "detect-libc@2.0.4": {
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
     },
-    "detective-amd@5.0.2": {
-      "integrity": "sha512-XFd/VEQ76HSpym80zxM68ieB77unNuoMwopU2TFT/ErUk5n4KvUTwW4beafAVUugrjV48l4BmmR0rh2MglBaiA==",
+    "detective-amd@6.0.1": {
+      "integrity": "sha512-TtyZ3OhwUoEEIhTFoc1C9IyJIud3y+xYkSRjmvCt65+ycQuc3VcBrPRTMWoO/AnuCyOB8T5gky+xf7Igxtjd3g==",
       "dependencies": [
         "ast-module-types",
         "escodegen",
@@ -2174,50 +2040,63 @@
         "node-source-walk"
       ]
     },
-    "detective-cjs@5.0.1": {
-      "integrity": "sha512-6nTvAZtpomyz/2pmEmGX1sXNjaqgMplhQkskq2MLrar0ZAIkHMrDhLXkRiK2mvbu9wSWr0V5/IfiTrZqAQMrmQ==",
+    "detective-cjs@6.0.1": {
+      "integrity": "sha512-tLTQsWvd2WMcmn/60T2inEJNhJoi7a//PQ7DwRKEj1yEeiQs4mrONgsUtEJKnZmrGWBBmE0kJ1vqOG/NAxwaJw==",
       "dependencies": [
         "ast-module-types",
         "node-source-walk"
       ]
     },
-    "detective-es6@4.0.1": {
-      "integrity": "sha512-k3Z5tB4LQ8UVHkuMrFOlvb3GgFWdJ9NqAa2YLUU/jTaWJIm+JJnEh4PsMc+6dfT223Y8ACKOaC0qcj7diIhBKw==",
+    "detective-es6@5.0.1": {
+      "integrity": "sha512-XusTPuewnSUdoxRSx8OOI6xIA/uld/wMQwYsouvFN2LAg7HgP06NF1lHRV3x6BZxyL2Kkoih4ewcq8hcbGtwew==",
       "dependencies": [
         "node-source-walk"
       ]
     },
-    "detective-postcss@6.1.3_postcss@8.5.3": {
-      "integrity": "sha512-7BRVvE5pPEvk2ukUWNQ+H2XOq43xENWbH0LcdCE14mwgTBEAMoAx+Fc1rdp76SmyZ4Sp48HlV7VedUnP6GA1Tw==",
+    "detective-postcss@7.0.1_postcss@8.5.3": {
+      "integrity": "sha512-bEOVpHU9picRZux5XnwGsmCN4+8oZo7vSW0O0/Enq/TO5R2pIAP2279NsszpJR7ocnQt4WXU0+nnh/0JuK4KHQ==",
       "dependencies": [
         "is-url",
         "postcss",
         "postcss-values-parser"
       ]
     },
-    "detective-sass@5.0.3": {
-      "integrity": "sha512-YsYT2WuA8YIafp2RVF5CEfGhhyIVdPzlwQgxSjK+TUm3JoHP+Tcorbk3SfG0cNZ7D7+cYWa0ZBcvOaR0O8+LlA==",
+    "detective-sass@6.0.1": {
+      "integrity": "sha512-jSGPO8QDy7K7pztUmGC6aiHkexBQT4GIH+mBAL9ZyBmnUIOFbkfZnO8wPRRJFP/QP83irObgsZHCoDHZ173tRw==",
       "dependencies": [
         "gonzales-pe",
         "node-source-walk"
       ]
     },
-    "detective-scss@4.0.3": {
-      "integrity": "sha512-VYI6cHcD0fLokwqqPFFtDQhhSnlFWvU614J42eY6G0s8c+MBhi9QAWycLwIOGxlmD8I/XvGSOUV1kIDhJ70ZPg==",
+    "detective-scss@5.0.1": {
+      "integrity": "sha512-MAyPYRgS6DCiS6n6AoSBJXLGVOydsr9huwXORUlJ37K3YLyiN0vYHpzs3AdJOgHobBfispokoqrEon9rbmKacg==",
       "dependencies": [
         "gonzales-pe",
         "node-source-walk"
       ]
     },
-    "detective-stylus@4.0.0": {
-      "integrity": "sha512-TfPotjhszKLgFBzBhTOxNHDsutIxx9GTWjrL5Wh7Qx/ydxKhwUrlSFeLIn+ZaHPF+h0siVBkAQSuy6CADyTxgQ=="
+    "detective-stylus@5.0.1": {
+      "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA=="
     },
-    "detective-typescript@11.2.0_typescript@5.8.3": {
-      "integrity": "sha512-ARFxjzizOhPqs1fYC/2NMC3N4jrQ6HvVflnXBTRqNEqJuXwyKLRr9CrJwkRcV/SnZt1sNXgsF6FPm0x57Tq0rw==",
+    "detective-typescript@14.0.0_typescript@5.8.3": {
+      "integrity": "sha512-pgN43/80MmWVSEi5LUuiVvO/0a9ss5V7fwVfrJ4QzAQRd3cwqU1SfWGXJFcNKUqoD5cS+uIovhw5t/0rSeC5Mw==",
       "dependencies": [
         "@typescript-eslint/typescript-estree",
         "ast-module-types",
         "node-source-walk",
+        "typescript"
+      ]
+    },
+    "detective-vue2@2.2.0_typescript@5.8.3": {
+      "integrity": "sha512-sVg/t6O2z1zna8a/UIV6xL5KUa2cMTQbdTIIvqNM0NIPswp52fe43Nwmbahzj3ww4D844u/vC2PYfiGLvD3zFA==",
+      "dependencies": [
+        "@dependents/detective-less",
+        "@vue/compiler-sfc",
+        "detective-es6",
+        "detective-sass",
+        "detective-scss",
+        "detective-stylus",
+        "detective-typescript",
         "typescript"
       ]
     },
@@ -2227,14 +2106,8 @@
         "dequal"
       ]
     },
-    "diff@7.0.0": {
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="
-    },
-    "dir-glob@3.0.1": {
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dependencies": [
-        "path-type@4.0.0"
-      ]
+    "diff@8.0.2": {
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="
     },
     "dot-prop@9.0.0": {
       "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
@@ -2262,8 +2135,8 @@
     "ee-first@1.1.1": {
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
-    "electron-to-chromium@1.5.155": {
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng=="
+    "electron-to-chromium@1.5.166": {
+      "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw=="
     },
     "emoji-regex-xs@1.0.0": {
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
@@ -2295,8 +2168,8 @@
     "entities@4.5.0": {
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
-    "entities@6.0.0": {
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="
+    "entities@6.0.1": {
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
     },
     "env-paths@3.0.0": {
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
@@ -2325,64 +2198,34 @@
         "es-errors"
       ]
     },
-    "esbuild@0.24.2": {
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+    "esbuild@0.25.5": {
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dependencies": [
-        "@esbuild/aix-ppc64@0.24.2",
-        "@esbuild/android-arm64@0.24.2",
-        "@esbuild/android-arm@0.24.2",
-        "@esbuild/android-x64@0.24.2",
-        "@esbuild/darwin-arm64@0.24.2",
-        "@esbuild/darwin-x64@0.24.2",
-        "@esbuild/freebsd-arm64@0.24.2",
-        "@esbuild/freebsd-x64@0.24.2",
-        "@esbuild/linux-arm64@0.24.2",
-        "@esbuild/linux-arm@0.24.2",
-        "@esbuild/linux-ia32@0.24.2",
-        "@esbuild/linux-loong64@0.24.2",
-        "@esbuild/linux-mips64el@0.24.2",
-        "@esbuild/linux-ppc64@0.24.2",
-        "@esbuild/linux-riscv64@0.24.2",
-        "@esbuild/linux-s390x@0.24.2",
-        "@esbuild/linux-x64@0.24.2",
-        "@esbuild/netbsd-arm64@0.24.2",
-        "@esbuild/netbsd-x64@0.24.2",
-        "@esbuild/openbsd-arm64@0.24.2",
-        "@esbuild/openbsd-x64@0.24.2",
-        "@esbuild/sunos-x64@0.24.2",
-        "@esbuild/win32-arm64@0.24.2",
-        "@esbuild/win32-ia32@0.24.2",
-        "@esbuild/win32-x64@0.24.2"
-      ]
-    },
-    "esbuild@0.25.4": {
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
-      "dependencies": [
-        "@esbuild/aix-ppc64@0.25.4",
-        "@esbuild/android-arm64@0.25.4",
-        "@esbuild/android-arm@0.25.4",
-        "@esbuild/android-x64@0.25.4",
-        "@esbuild/darwin-arm64@0.25.4",
-        "@esbuild/darwin-x64@0.25.4",
-        "@esbuild/freebsd-arm64@0.25.4",
-        "@esbuild/freebsd-x64@0.25.4",
-        "@esbuild/linux-arm64@0.25.4",
-        "@esbuild/linux-arm@0.25.4",
-        "@esbuild/linux-ia32@0.25.4",
-        "@esbuild/linux-loong64@0.25.4",
-        "@esbuild/linux-mips64el@0.25.4",
-        "@esbuild/linux-ppc64@0.25.4",
-        "@esbuild/linux-riscv64@0.25.4",
-        "@esbuild/linux-s390x@0.25.4",
-        "@esbuild/linux-x64@0.25.4",
-        "@esbuild/netbsd-arm64@0.25.4",
-        "@esbuild/netbsd-x64@0.25.4",
-        "@esbuild/openbsd-arm64@0.25.4",
-        "@esbuild/openbsd-x64@0.25.4",
-        "@esbuild/sunos-x64@0.25.4",
-        "@esbuild/win32-arm64@0.25.4",
-        "@esbuild/win32-ia32@0.25.4",
-        "@esbuild/win32-x64@0.25.4"
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-arm64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-arm64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
       ]
     },
     "escalade@3.2.0": {
@@ -2403,8 +2246,8 @@
         "source-map@0.6.1"
       ]
     },
-    "eslint-visitor-keys@3.4.3": {
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+    "eslint-visitor-keys@4.2.1": {
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="
     },
     "esprima@4.0.1": {
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
@@ -2436,36 +2279,19 @@
     "events@3.3.0": {
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
-    "execa@7.2.0": {
-      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-      "dependencies": [
-        "cross-spawn",
-        "get-stream@6.0.1",
-        "human-signals@4.3.1",
-        "is-stream@3.0.0",
-        "merge-stream",
-        "npm-run-path",
-        "onetime",
-        "signal-exit@3.0.7",
-        "strip-final-newline"
-      ]
-    },
     "execa@8.0.1": {
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dependencies": [
         "cross-spawn",
         "get-stream@8.0.1",
-        "human-signals@5.0.0",
+        "human-signals",
         "is-stream@3.0.0",
         "merge-stream",
         "npm-run-path",
         "onetime",
-        "signal-exit@4.1.0",
+        "signal-exit",
         "strip-final-newline"
       ]
-    },
-    "exsolve@1.0.4": {
-      "integrity": "sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw=="
     },
     "exsolve@1.0.5": {
       "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg=="
@@ -2474,7 +2300,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": [
         "@types/yauzl",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "get-stream@5.2.0",
         "yauzl"
       ]
@@ -2504,8 +2330,8 @@
         "pend"
       ]
     },
-    "fdir@6.4.4_picomatch@4.0.2": {
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+    "fdir@6.4.6_picomatch@4.0.2": {
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "dependencies": [
         "picomatch@4.0.2"
       ]
@@ -2529,18 +2355,11 @@
         "to-regex-range"
       ]
     },
-    "filter-obj@5.1.0": {
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="
+    "filter-obj@6.1.0": {
+      "integrity": "sha512-xdMtCAODmPloU9qtmPcdBV9Kd27NtMse+4ayThxqIHUES5Z2S6bGpap5PpdmNM56ub7y3i1eyr+vJJIIgWGKmA=="
     },
     "find-up-simple@1.0.1": {
       "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="
-    },
-    "find-up@6.3.0": {
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dependencies": [
-        "locate-path",
-        "path-exists"
-      ]
     },
     "find-up@7.0.0": {
       "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
@@ -2584,7 +2403,7 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dependencies": [
         "cross-spawn",
-        "signal-exit@4.1.0"
+        "signal-exit"
       ]
     },
     "formdata-polyfill@4.0.10": {
@@ -2599,43 +2418,17 @@
     "fresh@2.0.0": {
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
     },
-    "fs-constants@1.0.0": {
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
-    "fs-minipass@2.1.0": {
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dependencies": [
-        "minipass@3.3.6"
-      ]
-    },
-    "fs.realpath@1.0.0": {
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
     "fsevents@2.3.3": {
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
-    "gauge@3.0.2": {
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "dependencies": [
-        "aproba",
-        "color-support",
-        "console-control-strings",
-        "has-unicode",
-        "object-assign",
-        "signal-exit@3.0.7",
-        "string-width@4.2.3",
-        "strip-ansi@6.0.1",
-        "wide-align"
-      ]
-    },
     "gensync@1.0.0-beta.2": {
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
-    "get-amd-module-type@5.0.1": {
-      "integrity": "sha512-jb65zDeHyDjFR1loOVk0HQGM5WNwoGB8aLWy3LKCieMKol0/ProHkhO2X1JxojuN10vbz1qNn09MJ7tNp7qMzw==",
+    "get-amd-module-type@6.0.1": {
+      "integrity": "sha512-MtjsmYiCXcYDDrGqtNbeIYdAl85n+5mSv2r3FbzER/YV3ZILw4HNNIw34HuV5pyl0jzs6GFYU1VHVEefhgcNHQ==",
       "dependencies": [
         "ast-module-types",
         "node-source-walk"
@@ -2678,9 +2471,6 @@
         "pump"
       ]
     },
-    "get-stream@6.0.1": {
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-    },
     "get-stream@8.0.1": {
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="
     },
@@ -2707,30 +2497,9 @@
         "foreground-child",
         "jackspeak",
         "minimatch@9.0.5",
-        "minipass@7.1.2",
+        "minipass",
         "package-json-from-dist",
         "path-scurry"
-      ]
-    },
-    "glob@7.2.3": {
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": [
-        "fs.realpath",
-        "inflight",
-        "inherits",
-        "minimatch@3.1.2",
-        "once",
-        "path-is-absolute"
-      ]
-    },
-    "glob@8.1.0": {
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dependencies": [
-        "fs.realpath",
-        "inflight",
-        "inherits",
-        "minimatch@5.1.6",
-        "once"
       ]
     },
     "globals@11.12.0": {
@@ -2739,25 +2508,14 @@
     "globals@15.15.0": {
       "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="
     },
-    "globby@11.1.0": {
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dependencies": [
-        "array-union",
-        "dir-glob",
-        "fast-glob",
-        "ignore@5.3.2",
-        "merge2",
-        "slash@3.0.0"
-      ]
-    },
     "globby@14.1.0": {
       "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dependencies": [
         "@sindresorhus/merge-streams",
         "fast-glob",
-        "ignore@7.0.4",
-        "path-type@6.0.0",
-        "slash@5.1.0",
+        "ignore",
+        "path-type",
+        "slash",
         "unicorn-magic@0.3.0"
       ]
     },
@@ -2785,39 +2543,22 @@
         "duplexer"
       ]
     },
-    "h3@1.15.2": {
-      "integrity": "sha512-28QobU1/digpHI/kA9ttYnYtIS3QOtuvx3EY4IpFR+8Bh2C2ugY/ovSg/1LeqATXlznvZnwewWyP2S9lZPiMVA==",
-      "dependencies": [
-        "cookie-es@1.2.2",
-        "crossws",
-        "defu",
-        "destr@2.0.5",
-        "iron-webcrypto",
-        "node-mock-http",
-        "radix3",
-        "ufo@1.6.1",
-        "uncrypto"
-      ]
-    },
     "h3@1.15.3": {
       "integrity": "sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==",
       "dependencies": [
         "cookie-es@1.2.2",
         "crossws",
         "defu",
-        "destr@2.0.5",
+        "destr",
         "iron-webcrypto",
         "node-mock-http",
         "radix3",
-        "ufo@1.6.1",
+        "ufo",
         "uncrypto"
       ]
     },
     "has-symbols@1.1.0": {
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "has-unicode@2.0.1": {
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "hasown@2.0.2": {
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
@@ -2886,25 +2627,15 @@
     "http-shutdown@1.2.2": {
       "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw=="
     },
-    "https-proxy-agent@5.0.1": {
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": [
-        "agent-base@6.0.2",
-        "debug@4.4.0"
-      ]
-    },
     "https-proxy-agent@7.0.6": {
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
-        "agent-base@7.1.3",
-        "debug@4.4.0"
+        "agent-base",
+        "debug@4.4.1"
       ]
     },
     "httpxy@0.1.7": {
       "integrity": "sha512-pXNx8gnANKAndgga5ahefxc++tJvNL87CXoRwxn1cJE2ZkWEojF3tNfQIEhZX/vfpt+wzeAzpUI4qkediX1MLQ=="
-    },
-    "human-signals@4.3.1": {
-      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
     },
     "human-signals@5.0.0": {
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
@@ -2912,24 +2643,14 @@
     "ieee754@1.2.1": {
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
-    "ignore@5.3.2": {
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="
-    },
-    "ignore@7.0.4": {
-      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A=="
+    "ignore@7.0.5": {
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
     },
     "imurmurhash@0.1.4": {
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
     "index-to-position@1.1.0": {
       "integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg=="
-    },
-    "inflight@1.0.6": {
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dependencies": [
-        "once",
-        "wrappy"
-      ]
     },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
@@ -2939,7 +2660,7 @@
       "dependencies": [
         "@ioredis/commands",
         "cluster-key-slot",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "denque",
         "lodash.defaults",
         "lodash.isarguments",
@@ -2948,12 +2669,12 @@
         "standard-as-callback"
       ]
     },
-    "iovalkey@0.3.2": {
-      "integrity": "sha512-jGe3ZHI6NzNxjuH4gMgpyd5FnaRduLxkv801EgcdALxnY7f8MjHuZizibk+kRpVmtuePajS54Jv3OlrgAxGXPg==",
+    "iovalkey@0.3.3": {
+      "integrity": "sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==",
       "dependencies": [
         "@iovalkey/commands",
         "cluster-key-slot",
-        "debug@4.4.0",
+        "debug@4.4.1",
         "denque",
         "lodash.defaults",
         "lodash.isarguments",
@@ -3147,14 +2868,14 @@
         "crossws",
         "defu",
         "get-port-please",
-        "h3@1.15.3",
+        "h3",
         "http-shutdown",
         "jiti@2.4.2",
         "mlly",
         "node-forge",
         "pathe@1.1.2",
         "std-env",
-        "ufo@1.6.1",
+        "ufo",
         "untun",
         "uqr"
       ]
@@ -3182,20 +2903,8 @@
     "lodash.defaults@4.2.0": {
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
-    "lodash.difference@4.5.0": {
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
-    },
-    "lodash.flatten@4.4.0": {
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
-    },
     "lodash.isarguments@3.1.0": {
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    },
-    "lodash.isplainobject@4.0.6": {
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
-    },
-    "lodash.union@4.6.0": {
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
     },
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
@@ -3243,12 +2952,6 @@
         "@babel/parser",
         "@babel/types",
         "source-map-js"
-      ]
-    },
-    "make-dir@3.1.0": {
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dependencies": [
-        "semver@6.3.1"
       ]
     },
     "math-intrinsics@1.1.0": {
@@ -3347,54 +3050,29 @@
     "mini-svg-data-uri@1.4.4": {
       "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
     },
-    "minimatch@3.1.2": {
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": [
-        "brace-expansion@1.1.11"
-      ]
-    },
     "minimatch@5.1.6": {
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": [
-        "brace-expansion@2.0.1"
+        "brace-expansion"
       ]
     },
     "minimatch@9.0.5": {
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": [
-        "brace-expansion@2.0.1"
+        "brace-expansion"
       ]
     },
     "minimist@1.2.8": {
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
-    "minipass@3.3.6": {
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dependencies": [
-        "yallist@4.0.0"
-      ]
-    },
-    "minipass@5.0.0": {
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
-    },
     "minipass@7.1.2": {
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-    },
-    "minizlib@2.1.2": {
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dependencies": [
-        "minipass@3.3.6",
-        "yallist@4.0.0"
-      ]
     },
     "minizlib@3.0.2": {
       "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
       "dependencies": [
-        "minipass@7.1.2"
+        "minipass"
       ]
-    },
-    "mkdirp@1.0.4": {
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mkdirp@3.0.1": {
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
@@ -3405,11 +3083,11 @@
         "acorn",
         "pathe@2.0.3",
         "pkg-types@1.3.1",
-        "ufo@1.5.4"
+        "ufo"
       ]
     },
-    "module-definition@5.0.1": {
-      "integrity": "sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA==",
+    "module-definition@6.0.1": {
+      "integrity": "sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==",
       "dependencies": [
         "ast-module-types",
         "node-source-walk"
@@ -3430,9 +3108,6 @@
     "napi-wasm@1.1.3": {
       "integrity": "sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg=="
     },
-    "nested-error-stacks@2.1.1": {
-      "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw=="
-    },
     "netlify@13.3.5": {
       "integrity": "sha512-Nc3loyVASW59W+8fLDZT1lncpG7llffyZ2o0UQLx/Fr20i7P8oP+lE7+TEcFvXj9IUWU6LjB9P3BH+iFGyp+mg==",
       "dependencies": [
@@ -3444,7 +3119,7 @@
         "qs"
       ]
     },
-    "nitropack@2.11.12_rollup@4.40.2_magicast@0.3.5_db0@0.3.2_ioredis@5.6.1": {
+    "nitropack@2.11.12_rollup@4.43.0_magicast@0.3.5_db0@0.3.2_ioredis@5.6.1": {
       "integrity": "sha512-e2AdQrEY1IVoNTdyjfEQV93xkqz4SQxAMR0xWF8mZUUHxMLm6S4nPzpscjksmT4OdUxl0N8/DCaGjKQ9ghdodA==",
       "dependencies": [
         "@cloudflare/kv-asset-handler",
@@ -3453,11 +3128,11 @@
         "@rollup/plugin-commonjs",
         "@rollup/plugin-inject",
         "@rollup/plugin-json",
-        "@rollup/plugin-node-resolve@16.0.1_rollup@4.40.2",
+        "@rollup/plugin-node-resolve@16.0.1_rollup@4.43.0",
         "@rollup/plugin-replace",
         "@rollup/plugin-terser",
-        "@vercel/nft@0.29.3_rollup@4.40.2_acorn@8.14.1",
-        "archiver@7.0.1",
+        "@vercel/nft",
+        "archiver",
         "c12",
         "chokidar@4.0.3",
         "citty",
@@ -3469,15 +3144,15 @@
         "crossws",
         "db0",
         "defu",
-        "destr@2.0.5",
+        "destr",
         "dot-prop",
-        "esbuild@0.25.4",
+        "esbuild",
         "escape-string-regexp",
         "etag",
-        "exsolve@1.0.5",
-        "globby@14.1.0",
+        "exsolve",
+        "globby",
         "gzip-size@7.0.0",
-        "h3@1.15.3",
+        "h3",
         "hookable",
         "httpxy",
         "ioredis",
@@ -3499,14 +3174,14 @@
         "pretty-bytes",
         "radix3",
         "rollup-plugin-visualizer",
-        "rollup@4.40.2",
+        "rollup@4.43.0",
         "scule",
         "semver@7.7.2",
         "serve-placeholder",
         "serve-static@2.2.0",
         "source-map@0.7.4",
         "std-env",
-        "ufo@1.6.1",
+        "ufo",
         "ultrahtml",
         "uncrypto",
         "unctx",
@@ -3555,22 +3230,16 @@
     "node-releases@2.0.19": {
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
-    "node-source-walk@6.0.2": {
-      "integrity": "sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==",
+    "node-source-walk@7.0.1": {
+      "integrity": "sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==",
       "dependencies": [
         "@babel/parser"
-      ]
-    },
-    "nopt@5.0.0": {
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dependencies": [
-        "abbrev@1.1.1"
       ]
     },
     "nopt@8.1.0": {
       "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dependencies": [
-        "abbrev@3.0.1"
+        "abbrev"
       ]
     },
     "normalize-package-data@6.0.2": {
@@ -3596,15 +3265,6 @@
         "path-key@4.0.0"
       ]
     },
-    "npmlog@5.0.1": {
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "dependencies": [
-        "are-we-there-yet",
-        "console-control-strings",
-        "gauge",
-        "set-blocking"
-      ]
-    },
     "nypm@0.6.0": {
       "integrity": "sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg==",
       "dependencies": [
@@ -3615,18 +3275,15 @@
         "tinyexec@0.3.2"
       ]
     },
-    "object-assign@4.1.1": {
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
     "object-inspect@1.13.4": {
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
     "ofetch@1.4.1": {
       "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
       "dependencies": [
-        "destr@2.0.3",
+        "destr",
         "node-fetch-native",
-        "ufo@1.5.4"
+        "ufo"
       ]
     },
     "ohash@2.0.11": {
@@ -3672,10 +3329,10 @@
         "is-wsl@2.2.0"
       ]
     },
-    "p-event@5.0.1": {
-      "integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+    "p-event@6.0.1": {
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
       "dependencies": [
-        "p-timeout@5.1.0"
+        "p-timeout"
       ]
     },
     "p-limit@4.0.0": {
@@ -3693,16 +3350,13 @@
     "p-map@7.0.3": {
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA=="
     },
-    "p-timeout@5.1.0": {
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
-    },
     "p-timeout@6.1.4": {
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="
     },
     "p-wait-for@5.0.2": {
       "integrity": "sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==",
       "dependencies": [
-        "p-timeout@6.1.4"
+        "p-timeout"
       ]
     },
     "package-json-from-dist@1.0.1": {
@@ -3725,7 +3379,7 @@
     "parse5@7.3.0": {
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dependencies": [
-        "entities@6.0.0"
+        "entities@6.0.1"
       ]
     },
     "parseurl@1.3.3": {
@@ -3733,9 +3387,6 @@
     },
     "path-exists@5.0.0": {
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
-    },
-    "path-is-absolute@1.0.1": {
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
@@ -3750,14 +3401,11 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": [
         "lru-cache@10.4.3",
-        "minipass@7.1.2"
+        "minipass"
       ]
     },
     "path-to-regexp@6.3.0": {
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
-    },
-    "path-type@4.0.0": {
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "path-type@6.0.0": {
       "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="
@@ -3794,8 +3442,8 @@
     "pkg-types@2.1.0": {
       "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
       "dependencies": [
-        "confbox@0.2.1",
-        "exsolve@1.0.4",
+        "confbox@0.2.2",
+        "exsolve",
         "pathe@2.0.3"
       ]
     },
@@ -3816,11 +3464,11 @@
         "source-map-js"
       ]
     },
-    "precinct@11.0.5": {
-      "integrity": "sha512-oHSWLC8cL/0znFhvln26D14KfCQFFn4KOLSw6hmLhd+LQ2SKt9Ljm89but76Pc7flM9Ty1TnXyrA2u16MfRV3w==",
+    "precinct@12.2.0_postcss@8.5.3_typescript@5.8.3": {
+      "integrity": "sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==",
       "dependencies": [
         "@dependents/detective-less",
-        "commander@10.0.1",
+        "commander@12.1.0",
         "detective-amd",
         "detective-cjs",
         "detective-es6",
@@ -3829,8 +3477,11 @@
         "detective-scss",
         "detective-stylus",
         "detective-typescript",
+        "detective-vue2",
         "module-definition",
-        "node-source-walk"
+        "node-source-walk",
+        "postcss",
+        "typescript"
       ]
     },
     "pretty-bytes@6.1.1": {
@@ -3883,7 +3534,7 @@
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
       "dependencies": [
         "defu",
-        "destr@2.0.5"
+        "destr"
       ]
     },
     "read-package-up@11.0.0": {
@@ -3928,7 +3579,7 @@
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dependencies": [
         "abort-controller",
-        "buffer@6.0.3",
+        "buffer",
         "events",
         "process",
         "string_decoder@1.3.0"
@@ -3956,7 +3607,7 @@
         "esprima",
         "source-map@0.6.1",
         "tiny-invariant",
-        "tslib@2.8.1"
+        "tslib"
       ]
     },
     "redis-errors@1.2.0": {
@@ -4018,18 +3669,12 @@
     "reusify@1.1.0": {
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
     },
-    "rimraf@3.0.2": {
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": [
-        "glob@7.2.3"
-      ]
-    },
-    "rollup-plugin-visualizer@5.14.0_rollup@4.40.2": {
+    "rollup-plugin-visualizer@5.14.0_rollup@4.43.0": {
       "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
       "dependencies": [
         "open",
         "picomatch@4.0.2",
-        "rollup@4.40.2",
+        "rollup@4.43.0",
         "source-map@0.7.4",
         "yargs"
       ]
@@ -4061,29 +3706,29 @@
         "fsevents"
       ]
     },
-    "rollup@4.40.2": {
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+    "rollup@4.43.0": {
+      "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "dependencies": [
-        "@rollup/rollup-android-arm-eabi@4.40.2",
-        "@rollup/rollup-android-arm64@4.40.2",
-        "@rollup/rollup-darwin-arm64@4.40.2",
-        "@rollup/rollup-darwin-x64@4.40.2",
-        "@rollup/rollup-freebsd-arm64@4.40.2",
-        "@rollup/rollup-freebsd-x64@4.40.2",
-        "@rollup/rollup-linux-arm-gnueabihf@4.40.2",
-        "@rollup/rollup-linux-arm-musleabihf@4.40.2",
-        "@rollup/rollup-linux-arm64-gnu@4.40.2",
-        "@rollup/rollup-linux-arm64-musl@4.40.2",
-        "@rollup/rollup-linux-loongarch64-gnu@4.40.2",
-        "@rollup/rollup-linux-powerpc64le-gnu@4.40.2",
-        "@rollup/rollup-linux-riscv64-gnu@4.40.2",
-        "@rollup/rollup-linux-riscv64-musl@4.40.2",
-        "@rollup/rollup-linux-s390x-gnu@4.40.2",
-        "@rollup/rollup-linux-x64-gnu@4.40.2",
-        "@rollup/rollup-linux-x64-musl@4.40.2",
-        "@rollup/rollup-win32-arm64-msvc@4.40.2",
-        "@rollup/rollup-win32-ia32-msvc@4.40.2",
-        "@rollup/rollup-win32-x64-msvc@4.40.2",
+        "@rollup/rollup-android-arm-eabi@4.43.0",
+        "@rollup/rollup-android-arm64@4.43.0",
+        "@rollup/rollup-darwin-arm64@4.43.0",
+        "@rollup/rollup-darwin-x64@4.43.0",
+        "@rollup/rollup-freebsd-arm64@4.43.0",
+        "@rollup/rollup-freebsd-x64@4.43.0",
+        "@rollup/rollup-linux-arm-gnueabihf@4.43.0",
+        "@rollup/rollup-linux-arm-musleabihf@4.43.0",
+        "@rollup/rollup-linux-arm64-gnu@4.43.0",
+        "@rollup/rollup-linux-arm64-musl@4.43.0",
+        "@rollup/rollup-linux-loongarch64-gnu@4.43.0",
+        "@rollup/rollup-linux-powerpc64le-gnu@4.43.0",
+        "@rollup/rollup-linux-riscv64-gnu@4.43.0",
+        "@rollup/rollup-linux-riscv64-musl@4.43.0",
+        "@rollup/rollup-linux-s390x-gnu@4.43.0",
+        "@rollup/rollup-linux-x64-gnu@4.43.0",
+        "@rollup/rollup-linux-x64-musl@4.43.0",
+        "@rollup/rollup-win32-arm64-msvc@4.43.0",
+        "@rollup/rollup-win32-ia32-msvc@4.43.0",
+        "@rollup/rollup-win32-x64-msvc@4.43.0",
         "@types/estree",
         "fsevents"
       ]
@@ -4133,7 +3778,7 @@
     "send@1.2.0": {
       "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "dependencies": [
-        "debug@4.4.0",
+        "debug@4.4.1",
         "encodeurl@2.0.0",
         "escape-html",
         "etag",
@@ -4184,9 +3829,6 @@
         "parseurl",
         "send@1.2.0"
       ]
-    },
-    "set-blocking@2.0.0": {
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "setprototypeof@1.2.0": {
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
@@ -4249,9 +3891,6 @@
         "side-channel-weakmap"
       ]
     },
-    "signal-exit@3.0.7": {
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
     "signal-exit@4.1.0": {
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
@@ -4268,9 +3907,6 @@
         "mrmime",
         "totalist"
       ]
-    },
-    "slash@3.0.0": {
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slash@5.1.0": {
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
@@ -4355,8 +3991,8 @@
     "std-env@3.9.0": {
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
     },
-    "streamx@2.22.0": {
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+    "streamx@2.22.1": {
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
       "dependencies": [
         "bare-events",
         "fast-fifo",
@@ -4436,16 +4072,6 @@
     "system-architecture@0.1.0": {
       "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA=="
     },
-    "tar-stream@2.2.0": {
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": [
-        "bl",
-        "end-of-stream",
-        "fs-constants",
-        "inherits",
-        "readable-stream@3.6.2"
-      ]
-    },
     "tar-stream@3.1.7": {
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dependencies": [
@@ -4454,25 +4080,14 @@
         "streamx"
       ]
     },
-    "tar@6.2.1": {
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dependencies": [
-        "chownr@2.0.0",
-        "fs-minipass",
-        "minipass@5.0.0",
-        "minizlib@2.1.2",
-        "mkdirp@1.0.4",
-        "yallist@4.0.0"
-      ]
-    },
     "tar@7.4.3": {
       "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dependencies": [
         "@isaacs/fs-minipass",
-        "chownr@3.0.0",
-        "minipass@7.1.2",
-        "minizlib@3.0.2",
-        "mkdirp@3.0.1",
+        "chownr",
+        "minipass",
+        "minizlib",
+        "mkdirp",
         "yallist@5.0.0"
       ]
     },
@@ -4483,8 +4098,8 @@
         "solid-use"
       ]
     },
-    "terser@5.39.2": {
-      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
+    "terser@5.42.0": {
+      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
       "dependencies": [
         "@jridgewell/source-map",
         "acorn",
@@ -4510,8 +4125,8 @@
     "tinyexec@1.0.1": {
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="
     },
-    "tinyglobby@0.2.13_picomatch@4.0.2": {
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+    "tinyglobby@0.2.14_picomatch@4.0.2": {
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dependencies": [
         "fdir",
         "picomatch@4.0.2"
@@ -4550,27 +4165,20 @@
     "triple-beam@1.4.1": {
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
     },
-    "tslib@1.14.1": {
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "ts-api-utils@2.1.0_typescript@5.8.3": {
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dependencies": [
+        "typescript"
+      ]
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "tsutils@3.21.0_typescript@5.8.3": {
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dependencies": [
-        "tslib@1.14.1",
-        "typescript"
-      ]
     },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
     },
     "typescript@5.8.3": {
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="
-    },
-    "ufo@1.5.4": {
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
     },
     "ufo@1.6.1": {
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="
@@ -4596,14 +4204,14 @@
         "acorn",
         "estree-walker@3.0.3",
         "magic-string",
-        "unplugin@2.3.4"
+        "unplugin@2.3.5"
       ]
     },
     "undici-types@5.28.4": {
       "integrity": "sha512-3OeMF5Lyowe8VW0skf5qaIE7Or3yS9LS7fvMUI0gg4YxpIBVg0L8BxCmROw2CcYhSkpR68Epz7CGc8MPj94Uww=="
     },
-    "undici-types@6.19.8": {
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "unenv@1.10.0": {
       "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
@@ -4619,10 +4227,10 @@
       "integrity": "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg==",
       "dependencies": [
         "defu",
-        "exsolve@1.0.5",
+        "exsolve",
         "ohash",
         "pathe@2.0.3",
-        "ufo@1.6.1"
+        "ufo"
       ]
     },
     "unicorn-magic@0.1.0": {
@@ -4647,7 +4255,7 @@
         "strip-literal",
         "tinyglobby",
         "unplugin-utils",
-        "unplugin@2.3.4"
+        "unplugin@2.3.5"
       ]
     },
     "unist-util-is@6.0.0": {
@@ -4689,12 +4297,12 @@
         "normalize-path@2.1.1"
       ]
     },
-    "unocss@66.1.3": {
-      "integrity": "sha512-hjSZ+ekyzVfVNMXeBnTMMatwPP/VaaE9UFyEKJfCctaiex11Dsj1MCjj6PIjGUZyIWzAJp6BZdcVmHyOi09HGw==",
+    "unocss@66.2.0": {
+      "integrity": "sha512-cAOwKnjcXZPXthg97oiQN0V7G0E44bbSqLoCvO3ukeHdu2/xKnAZgDJudAnKe/LT7HOYYbBHxUUPEtAjy4Ob6Q==",
       "dependencies": [
         "@unocss/astro",
         "@unocss/cli",
-        "@unocss/core@66.1.3",
+        "@unocss/core@66.2.0",
         "@unocss/postcss",
         "@unocss/preset-attributify",
         "@unocss/preset-icons",
@@ -4727,8 +4335,8 @@
         "webpack-virtual-modules"
       ]
     },
-    "unplugin@2.3.4": {
-      "integrity": "sha512-m4PjxTurwpWfpMomp8AptjD5yj8qEZN5uQjjGM3TAs9MWWD2tXSSNNj6jGR2FoVGod4293ytyV6SwBbertfyJg==",
+    "unplugin@2.3.5": {
+      "integrity": "sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==",
       "dependencies": [
         "acorn",
         "picomatch@4.0.2",
@@ -4741,13 +4349,13 @@
         "anymatch",
         "chokidar@4.0.3",
         "db0",
-        "destr@2.0.5",
-        "h3@1.15.3",
+        "destr",
+        "h3",
         "ioredis",
         "lru-cache@10.4.3",
         "node-fetch-native",
         "ofetch",
-        "ufo@1.6.1"
+        "ufo"
       ]
     },
     "untun@0.1.3": {
@@ -4779,7 +4387,7 @@
         "unplugin@1.16.1"
       ]
     },
-    "update-browserslist-db@1.1.3_browserslist@4.24.5": {
+    "update-browserslist-db@1.1.3_browserslist@4.25.0": {
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dependencies": [
         "browserslist",
@@ -4826,8 +4434,8 @@
         "vfile-message"
       ]
     },
-    "vinxi@0.5.6_@babel+core@7.27.1": {
-      "integrity": "sha512-K9zaoHEdLXSVw3akoKcpRaRaGNZcXAnB0XBcke74y0FbXqcR3+rlFxOH/Pi3Maq3K7wAPBGyE91HW0lATfv5Kg==",
+    "vinxi@0.5.7_@babel+core@7.27.4": {
+      "integrity": "sha512-8+xsAx/+J+QENGV2igI29u1/gvlFKeXYBAsIk1OOzt9USmLxyaqBHf+GvkiZ8QgPTFP9OyA2w+TuPynyushr7g==",
       "dependencies": [
         "@babel/core",
         "@babel/plugin-syntax-jsx",
@@ -4842,10 +4450,9 @@
         "dax-sh",
         "defu",
         "es-module-lexer",
-        "esbuild@0.25.4",
-        "fast-glob",
+        "esbuild",
         "get-port-please",
-        "h3@1.15.2",
+        "h3",
         "hookable",
         "http-proxy",
         "micromatch",
@@ -4857,15 +4464,16 @@
         "resolve@1.22.10",
         "serve-placeholder",
         "serve-static@1.16.2",
-        "ufo@1.6.1",
+        "tinyglobby",
+        "ufo",
         "unctx",
         "unenv@1.10.0",
         "unstorage",
-        "vite@6.3.5_picomatch@4.0.2",
+        "vite",
         "zod"
       ]
     },
-    "vite-plugin-solid@2.11.6_solid-js@1.9.7__seroval@1.3.1_vite@6.3.5__picomatch@4.0.2_@babel+core@7.27.1": {
+    "vite-plugin-solid@2.11.6_solid-js@1.9.7__seroval@1.3.1_vite@6.3.5__picomatch@4.0.2_@babel+core@7.27.4": {
       "integrity": "sha512-Sl5CTqJTGyEeOsmdH6BOgalIZlwH3t4/y0RQuFLMGnvWMBvxb4+lq7x3BSiAw6etf0QexfNJW7HSOO/Qf7pigg==",
       "dependencies": [
         "@babel/core",
@@ -4874,35 +4482,26 @@
         "merge-anything",
         "solid-js",
         "solid-refresh",
-        "vite@6.3.5_picomatch@4.0.2",
+        "vite",
         "vitefu"
-      ]
-    },
-    "vite@6.1.4": {
-      "integrity": "sha512-VzONrF/qqEg/JBwHXBJdVSmBZBhwiPGinyUb0SQLByqQwi6o8UvX5TWLkpvkq3tvN8Cr273ieZDt36CGwWRMvA==",
-      "dependencies": [
-        "esbuild@0.24.2",
-        "fsevents",
-        "postcss",
-        "rollup@4.40.2"
       ]
     },
     "vite@6.3.5_picomatch@4.0.2": {
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dependencies": [
-        "esbuild@0.25.4",
+        "esbuild",
         "fdir",
         "fsevents",
         "picomatch@4.0.2",
         "postcss",
-        "rollup@4.40.2",
+        "rollup@4.43.0",
         "tinyglobby"
       ]
     },
     "vitefu@1.0.6_vite@6.3.5__picomatch@4.0.2": {
       "integrity": "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==",
       "dependencies": [
-        "vite@6.3.5_picomatch@4.0.2"
+        "vite"
       ]
     },
     "vue-flow-layout@0.1.1_vue@3.5.16": {
@@ -4947,12 +4546,6 @@
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dependencies": [
         "isexe@3.1.1"
-      ]
-    },
-    "wide-align@1.1.5": {
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dependencies": [
-        "string-width@4.2.3"
       ]
     },
     "widest-line@5.0.0": {
@@ -5016,7 +4609,7 @@
       "integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
       "dependencies": [
         "imurmurhash",
-        "signal-exit@4.1.0"
+        "signal-exit"
       ]
     },
     "y18n@5.0.8": {
@@ -5024,9 +4617,6 @@
     },
     "yallist@3.1.1": {
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "yallist@4.0.0": {
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yallist@5.0.0": {
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
@@ -5063,33 +4653,26 @@
         "error-stack-parser-es"
       ]
     },
-    "youch@4.1.0-beta.7": {
-      "integrity": "sha512-HUn0M24AUTMvjdkoMtH8fJz2FEd+k1xvtR9EoTrDUoVUi6o7xl5X+pST/vjk4T3GEQo2mJ9FlAvhWBm8dIdD4g==",
+    "youch@4.1.0-beta.8": {
+      "integrity": "sha512-rY2A2lSF7zC+l7HH9Mq+83D1dLlsPnEvy8jTouzaptDZM6geqZ3aJe/b7ULCwRURPtWV3vbDjA2DDMdoBol0HQ==",
       "dependencies": [
+        "@poppinss/colors",
         "@poppinss/dumper",
         "@speed-highlight/core",
         "cookie",
         "youch-core"
       ]
     },
-    "zip-stream@4.1.1": {
-      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
-      "dependencies": [
-        "archiver-utils@3.0.4",
-        "compress-commons@4.1.2",
-        "readable-stream@3.6.2"
-      ]
-    },
     "zip-stream@6.0.1": {
       "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
       "dependencies": [
-        "archiver-utils@5.0.2",
-        "compress-commons@6.0.2",
+        "archiver-utils",
+        "compress-commons",
         "readable-stream@4.7.0"
       ]
     },
-    "zod@3.24.4": {
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="
+    "zod@3.25.63": {
+      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw=="
     },
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
@@ -5101,14 +4684,14 @@
         "npm:@iconify-json/flowbite@^1.2.5",
         "npm:@solidjs/router@0.15",
         "npm:@solidjs/start@^1.1.4",
-        "npm:@unocss/preset-wind4@^66.1.3",
+        "npm:@unocss/preset-wind4@^66.2.0",
         "npm:@vonagam/unocss-preset-flowbite@^0.0.1",
         "npm:flowbite@^3.1.2",
-        "npm:iovalkey@~0.3.2",
+        "npm:iovalkey@~0.3.3",
         "npm:lean-qr@^2.5.0",
         "npm:solid-js@^1.9.7",
-        "npm:unocss@^66.1.3",
-        "npm:vinxi@~0.5.6"
+        "npm:unocss@^66.2.0",
+        "npm:vinxi@~0.5.7"
       ]
     }
   }

--- a/services/demo-shop/deno.lock
+++ b/services/demo-shop/deno.lock
@@ -4,13 +4,13 @@
     "npm:@iconify-json/flowbite@^1.2.5": "1.2.5",
     "npm:@solidjs/router@0.15": "0.15.3_solid-js@1.9.7__seroval@1.3.1",
     "npm:@solidjs/start@^1.1.4": "1.1.4_vinxi@0.5.6__@babel+core@7.27.1_seroval@1.3.1_solid-js@1.9.7__seroval@1.3.1",
-    "npm:@unocss/preset-wind4@^66.1.2": "66.1.2",
+    "npm:@unocss/preset-wind4@^66.1.3": "66.1.3",
     "npm:@vonagam/unocss-preset-flowbite@^0.0.1": "0.0.1_@unocss+core@0.65.4",
     "npm:flowbite@^3.1.2": "3.1.2",
-    "npm:iovalkey@~0.3.1": "0.3.1",
+    "npm:iovalkey@~0.3.2": "0.3.2",
     "npm:lean-qr@^2.5.0": "2.5.0",
     "npm:solid-js@^1.9.7": "1.9.7_seroval@1.3.1",
-    "npm:unocss@^66.1.2": "66.1.2",
+    "npm:unocss@^66.1.3": "66.1.3",
     "npm:vinxi@~0.5.6": "0.5.6_@babel+core@7.27.1"
   },
   "npm": {
@@ -215,17 +215,11 @@
     "@esbuild/aix-ppc64@0.24.2": {
       "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="
     },
-    "@esbuild/aix-ppc64@0.25.2": {
-      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag=="
-    },
     "@esbuild/aix-ppc64@0.25.4": {
       "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="
     },
     "@esbuild/android-arm64@0.24.2": {
       "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="
-    },
-    "@esbuild/android-arm64@0.25.2": {
-      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w=="
     },
     "@esbuild/android-arm64@0.25.4": {
       "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A=="
@@ -233,17 +227,11 @@
     "@esbuild/android-arm@0.24.2": {
       "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="
     },
-    "@esbuild/android-arm@0.25.2": {
-      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA=="
-    },
     "@esbuild/android-arm@0.25.4": {
       "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="
     },
     "@esbuild/android-x64@0.24.2": {
       "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="
-    },
-    "@esbuild/android-x64@0.25.2": {
-      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg=="
     },
     "@esbuild/android-x64@0.25.4": {
       "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ=="
@@ -251,17 +239,11 @@
     "@esbuild/darwin-arm64@0.24.2": {
       "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="
     },
-    "@esbuild/darwin-arm64@0.25.2": {
-      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA=="
-    },
     "@esbuild/darwin-arm64@0.25.4": {
       "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g=="
     },
     "@esbuild/darwin-x64@0.24.2": {
       "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="
-    },
-    "@esbuild/darwin-x64@0.25.2": {
-      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA=="
     },
     "@esbuild/darwin-x64@0.25.4": {
       "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A=="
@@ -269,17 +251,11 @@
     "@esbuild/freebsd-arm64@0.24.2": {
       "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="
     },
-    "@esbuild/freebsd-arm64@0.25.2": {
-      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w=="
-    },
     "@esbuild/freebsd-arm64@0.25.4": {
       "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ=="
     },
     "@esbuild/freebsd-x64@0.24.2": {
       "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="
-    },
-    "@esbuild/freebsd-x64@0.25.2": {
-      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ=="
     },
     "@esbuild/freebsd-x64@0.25.4": {
       "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ=="
@@ -287,17 +263,11 @@
     "@esbuild/linux-arm64@0.24.2": {
       "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="
     },
-    "@esbuild/linux-arm64@0.25.2": {
-      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g=="
-    },
     "@esbuild/linux-arm64@0.25.4": {
       "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ=="
     },
     "@esbuild/linux-arm@0.24.2": {
       "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="
-    },
-    "@esbuild/linux-arm@0.25.2": {
-      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g=="
     },
     "@esbuild/linux-arm@0.25.4": {
       "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ=="
@@ -305,17 +275,11 @@
     "@esbuild/linux-ia32@0.24.2": {
       "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="
     },
-    "@esbuild/linux-ia32@0.25.2": {
-      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ=="
-    },
     "@esbuild/linux-ia32@0.25.4": {
       "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ=="
     },
     "@esbuild/linux-loong64@0.24.2": {
       "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="
-    },
-    "@esbuild/linux-loong64@0.25.2": {
-      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w=="
     },
     "@esbuild/linux-loong64@0.25.4": {
       "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA=="
@@ -323,17 +287,11 @@
     "@esbuild/linux-mips64el@0.24.2": {
       "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="
     },
-    "@esbuild/linux-mips64el@0.25.2": {
-      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q=="
-    },
     "@esbuild/linux-mips64el@0.25.4": {
       "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg=="
     },
     "@esbuild/linux-ppc64@0.24.2": {
       "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="
-    },
-    "@esbuild/linux-ppc64@0.25.2": {
-      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g=="
     },
     "@esbuild/linux-ppc64@0.25.4": {
       "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag=="
@@ -341,17 +299,11 @@
     "@esbuild/linux-riscv64@0.24.2": {
       "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="
     },
-    "@esbuild/linux-riscv64@0.25.2": {
-      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw=="
-    },
     "@esbuild/linux-riscv64@0.25.4": {
       "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA=="
     },
     "@esbuild/linux-s390x@0.24.2": {
       "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="
-    },
-    "@esbuild/linux-s390x@0.25.2": {
-      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q=="
     },
     "@esbuild/linux-s390x@0.25.4": {
       "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g=="
@@ -359,17 +311,11 @@
     "@esbuild/linux-x64@0.24.2": {
       "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="
     },
-    "@esbuild/linux-x64@0.25.2": {
-      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg=="
-    },
     "@esbuild/linux-x64@0.25.4": {
       "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA=="
     },
     "@esbuild/netbsd-arm64@0.24.2": {
       "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="
-    },
-    "@esbuild/netbsd-arm64@0.25.2": {
-      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw=="
     },
     "@esbuild/netbsd-arm64@0.25.4": {
       "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ=="
@@ -377,17 +323,11 @@
     "@esbuild/netbsd-x64@0.24.2": {
       "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="
     },
-    "@esbuild/netbsd-x64@0.25.2": {
-      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg=="
-    },
     "@esbuild/netbsd-x64@0.25.4": {
       "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw=="
     },
     "@esbuild/openbsd-arm64@0.24.2": {
       "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="
-    },
-    "@esbuild/openbsd-arm64@0.25.2": {
-      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg=="
     },
     "@esbuild/openbsd-arm64@0.25.4": {
       "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A=="
@@ -395,17 +335,11 @@
     "@esbuild/openbsd-x64@0.24.2": {
       "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="
     },
-    "@esbuild/openbsd-x64@0.25.2": {
-      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw=="
-    },
     "@esbuild/openbsd-x64@0.25.4": {
       "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw=="
     },
     "@esbuild/sunos-x64@0.24.2": {
       "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="
-    },
-    "@esbuild/sunos-x64@0.25.2": {
-      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA=="
     },
     "@esbuild/sunos-x64@0.25.4": {
       "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q=="
@@ -413,26 +347,17 @@
     "@esbuild/win32-arm64@0.24.2": {
       "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="
     },
-    "@esbuild/win32-arm64@0.25.2": {
-      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q=="
-    },
     "@esbuild/win32-arm64@0.25.4": {
       "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ=="
     },
     "@esbuild/win32-ia32@0.24.2": {
       "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="
     },
-    "@esbuild/win32-ia32@0.25.2": {
-      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg=="
-    },
     "@esbuild/win32-ia32@0.25.4": {
       "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="
     },
     "@esbuild/win32-x64@0.24.2": {
       "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="
-    },
-    "@esbuild/win32-x64@0.25.2": {
-      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="
     },
     "@esbuild/win32-x64@0.25.4": {
       "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="
@@ -1197,20 +1122,20 @@
     "@ungap/structured-clone@1.3.0": {
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
-    "@unocss/astro@66.1.2": {
-      "integrity": "sha512-QBcvrPp0F2jqe2Y/S/FQDmEmNlAhGjeWN5fkUGj02N7mXRrg0/VJxSpOJH6XHRWkMoFPoNNyEjHk563ODbjtHw==",
+    "@unocss/astro@66.1.3": {
+      "integrity": "sha512-jsubeNZE/LThm8fXPMWNmNXmG5KsM4LIpJ37rq5tgP6RqX0UwLvA4t9yXNJdr6aLDJN6+KpQXfGhIrf/Aj7YIQ==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/reset",
         "@unocss/vite"
       ]
     },
-    "@unocss/cli@66.1.2": {
-      "integrity": "sha512-bYCRpkGMu0QwC6Ktq3S/HwtcIW8Famy0dXOu1RIAM1IT60lq+4S5UTEBPdwryoFgDBoVMB7KLUhPYiGQ3pmSTA==",
+    "@unocss/cli@66.1.3": {
+      "integrity": "sha512-7Uw6VDsk7w6E6PkrRfq34d+tJpTcNWfksNkLorpQhwwlpbIod69iNHj5gn5u0SJwrAAuFvGNTQzOWQar8HlKCQ==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/preset-uno",
         "cac",
         "chokidar@3.6.0",
@@ -1223,29 +1148,29 @@
         "unplugin-utils"
       ]
     },
-    "@unocss/config@66.1.2": {
-      "integrity": "sha512-2sQXj+Qaq4RVDELVTPoXMggZ30g1WKHeCuur396I12Ab0HgAR6bTc/DIrNtqKVHFI3mmlvP1oM1ynhKWSKPsTg==",
+    "@unocss/config@66.1.3": {
+      "integrity": "sha512-oEKomMMY+f6+4HkU538XG7jOJZAMMk2WczT2XS6HdpJWwUzSKHlhs9R2pj7g0HLJZsROzP1A1+OBstHcQLe94A==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "unconfig"
       ]
     },
     "@unocss/core@0.65.4": {
       "integrity": "sha512-a2JOoFutrhqd5RgPhIR5FIXrDoHDU3gwCbPrpT6KYTjsqlSc/fv02yZ+JGOZFN3MCFhCmaPTs+idDFtwb3xU8g=="
     },
-    "@unocss/core@66.1.2": {
-      "integrity": "sha512-mN9h1hHEuhDcdbI4z74o7UnxlBZYVsJpYcdC1YLWBKROcLYTkuyZ7hgBzpo1FBNox2Bt3JnrSinVDmc44Bxjow=="
+    "@unocss/core@66.1.3": {
+      "integrity": "sha512-qV88JvRvSMgMo1FMWZfNiKYy+IvaXswyMMyZvuQxCrNkDPtij46pu7G3heKdLl7mNTdSgF0+LQPEqVYVA27pCA=="
     },
-    "@unocss/extractor-arbitrary-variants@66.1.2": {
-      "integrity": "sha512-F570wH9VYeFTb4r8qgcbN5QpEVIAvFC1zOnrAPUr6B6kbU2YChMXxHP7PHK0AzLHnEr458Pwpzl6hmP6bzxZ8g==",
+    "@unocss/extractor-arbitrary-variants@66.1.3": {
+      "integrity": "sha512-4nlQKx40ch+4hjNlN/jWZDd06qbXFj5xwMpnNjDcb008zgCuPK2dEmg/eDddSv25KZh9W+3fvwduMDNK6YDooQ==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/inspector@66.1.2": {
-      "integrity": "sha512-ftdZzFP5DAKDzgBI078xDDZbNNVq1RV/yhpNkviBvWCUsgRWc6o3G8swqJPIvFaphmUms0RIYH9shmXilVXFtA==",
+    "@unocss/inspector@66.1.3": {
+      "integrity": "sha512-ntKtc9ZJBrYf6BFZlwfWwDCWKvZQd3A3W4i0NGdHXlzAC3CFGf19U355e49DfKCln6zDtTVHTPWCuMzMH2H52Q==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/rule-utils",
         "colorette",
         "gzip-size@6.0.0",
@@ -1253,139 +1178,139 @@
         "vue-flow-layout"
       ]
     },
-    "@unocss/postcss@66.1.2_postcss@8.5.3": {
-      "integrity": "sha512-RCA3or1qBdRVduNW73xdeiFDCEb8cvcGKsHSN66rL66RrlzNnunE4NE55vbI+yoArTRZ7RdUnxq1KuXKjrJbYw==",
+    "@unocss/postcss@66.1.3_postcss@8.5.3": {
+      "integrity": "sha512-kVJlJ19WnG0Ec4BpdJUcUaA/B5md440WiKId2oaD6nzT6IDozpbQ3DwW2HtQ33YyagkmwYgocb0oodEm2lGilA==",
       "dependencies": [
         "@unocss/config",
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/rule-utils",
         "css-tree",
         "postcss",
         "tinyglobby"
       ]
     },
-    "@unocss/preset-attributify@66.1.2": {
-      "integrity": "sha512-i7+LRtpxbtSzS+gHdc+aW99mGLYeR8hUnEWqFNnr+MiiyzbD8yFimye/u8TySSBLzPKGbLCb4YWVV684BuZgxA==",
+    "@unocss/preset-attributify@66.1.3": {
+      "integrity": "sha512-geEaGxs7j85P1HirbAlIRnCrJwxjvvbUQDC2TOXUZ67So1co2mac/3uo0QMJsdry14iSIIfu6rNVaDjMSC4K5g==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/preset-icons@66.1.2": {
-      "integrity": "sha512-14390jFBJ2anuKvjX9TeRCm7adNjR/mey0bh0+S/k/5W3VugIY2y0E+OH3m+sx5d/5ZUYbYkUGsmtuKbVNwwxQ==",
+    "@unocss/preset-icons@66.1.3": {
+      "integrity": "sha512-n1y8I4cVfOOldgyuncwtMn8/wMVzUzVvwdgQk2ow/D07TBgsyZZfk98N1AAFrS772SRr8+YmJ5im4+bNLZaYdA==",
       "dependencies": [
         "@iconify/utils",
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "ofetch"
       ]
     },
-    "@unocss/preset-mini@66.1.2": {
-      "integrity": "sha512-oiDe+VhwZ8B5Z0UGfggtOwgpRZMLtH1RTDFvmJmJEXYYX5BPWknS6wYcQzxy0i/y9ym0xp2QnEaTpGmR7LKdkg==",
+    "@unocss/preset-mini@66.1.3": {
+      "integrity": "sha512-8HYCTl0YK5FGzfVbtshN1MIQfNZy8baT4BLdcDb2qtsLjG5qP7rmqTdk3c8OpoKhGLUuXPXBaDjh+D5TAMBY3w==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-tagify@66.1.2": {
-      "integrity": "sha512-Xw5sFJGuzmGnfAXMI0kAiWDBh4DT3cOyphcyY9grBxbmxgqQDxRFHOV3Eg85lWK6X5cScOv3DhO0ndGv5ND8YA==",
+    "@unocss/preset-tagify@66.1.3": {
+      "integrity": "sha512-IUhggch3uaDraTgnomjo9eRIsarI3r3Wy5Cyu5GtmAIs4RIe7MTVsGeL21q7qgC12/UmQ7E9zdyJR1IbQ6L9aQ==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/preset-typography@66.1.2": {
-      "integrity": "sha512-+k9zp27Ak8rB6LPFDwq9fcwd3+ivFeSvXFQ2d4fBCwGGOAKHIA7qHLg3etxRaMhGd3YUPv/6d7FWpBbQgUVYZw==",
+    "@unocss/preset-typography@66.1.3": {
+      "integrity": "sha512-97n8xIYwQlxhor0FiLsmp697G6DTmUauFNv1trJf2d2wBP2W/AAkIbKw0t8SEN06eduvB7Epq7h7502dyULV4A==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-uno@66.1.2": {
-      "integrity": "sha512-JL9YkDwluu1YGhzBaxO60XkKtZBagL13z3K6dsjsghbs+dKVlh35rhlIm5TZ+NdLAzcLM8PHhXm2ausjSd54Bg==",
+    "@unocss/preset-uno@66.1.3": {
+      "integrity": "sha512-JM/6cMGX3xSdU2a+S0JOl3aEWlQoOv0J3yyyQgd0lamkWF3RhRON6QZwhcMaLGVAPwVrSfaLG2ucCH9uubGpdg==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/preset-web-fonts@66.1.2": {
-      "integrity": "sha512-2ru+6jaac72oUx0kOBgNzbbkVe6oWKjqGmx24uK94fAcrP9eQyd+r7xiFpqXegrQ8+kONI66+HxAClvF2JHqdw==",
+    "@unocss/preset-web-fonts@66.1.3": {
+      "integrity": "sha512-uOWEmru+tbr/gttM6X/sJHoY0TCVdUx8/EiVITrLe51Agi2UECQlCdBH2lZNnfc3RCArCn4JevMLHd1btHRzJg==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "ofetch"
       ]
     },
-    "@unocss/preset-wind3@66.1.2": {
-      "integrity": "sha512-S09imGOngAAOXCBCHb3JAtxD1/L7nDWrgEeX6NT0ElDp3X1T6XxUXYJlpjCfcqV/klMoXyYouKvp0YuG9QSgVg==",
+    "@unocss/preset-wind3@66.1.3": {
+      "integrity": "sha512-oFQKA/v0EbCtZaxTBKvTfyVG1hcDJ1CXQ7gsghynMpOKMJbnb7bq4NEuDoMdHCVV9yKEQaSXkbbyHpeithBO3g==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind4@66.1.2": {
-      "integrity": "sha512-03p4rpBAWzz58BzAiKsUuG+6YO7IG6mJMGQAtPzuhd+nVBJLIRa3eBIVXOPmAVz1rNx5XPRTAr6PMC7ycdMFRA==",
+    "@unocss/preset-wind4@66.1.3": {
+      "integrity": "sha512-QwPDtQv/Asz1sYT0HcXPROolKwDCCcHqp0kkrO7aOGaVqyTF6ByfT+7cfI+Mv9uKtZejd+kQTUM/1ag8mzj3UA==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind@66.1.2": {
-      "integrity": "sha512-O3nIfbTbX/YRMFj7jNb7nHBDV47G79qOmyid4WPFZrPV3BbFAo94d/54kSoDVuc8jAt06YYQH9XC4ZeD59Sr3Q==",
+    "@unocss/preset-wind@66.1.3": {
+      "integrity": "sha512-PA+W1n3b7vXYAp3bD5BoSXVHDVhXPXOpKkEYDhMHL8+z567/dwDVrkZ5vAPsu1s4bW1PLqN/enzKso74TOfDCg==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/reset@66.1.2": {
-      "integrity": "sha512-njNy/QCpuPKBFeEvhYGwwCe3t8R8JTxONsyUB9NsFOamkF13DSlEB4Yy/QLQfIinbbmx0F/wiej/JGOJk1ecDg=="
+    "@unocss/reset@66.1.3": {
+      "integrity": "sha512-tc8uSka0R0zlfJfOjoLUg0NMT4RQnAe6nyelBXE86qYQaNV2YD7tf2iEWMmbjNwmiIjc8MigHAvYt1HmdirNww=="
     },
-    "@unocss/rule-utils@66.1.2": {
-      "integrity": "sha512-nn0ehvDh7yyWq2mcBDLVpmMAivjRATUroZ8ETinyN1rmfsGesm71R0d1gV3K+Z6YC7a3+dMLc+/qzI7VK3AG/Q==",
+    "@unocss/rule-utils@66.1.3": {
+      "integrity": "sha512-EP8QRcOO/dAD1+RxOnWOiGaIyo4IJQOdqD0nBteZDoL3X9vj6GPUI5yo8f7uR6k0koI/hxJv5BVsfQZSIsVjLA==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "magic-string"
       ]
     },
-    "@unocss/transformer-attributify-jsx@66.1.2": {
-      "integrity": "sha512-PNwxpsQlBlTAyw1apIMyioeAKrLAf7axLDjZ4BW20WH7ql0GUwvMhuO/qzsWDpYWdtSlFnnAdWI2aCxyvhzdCA==",
+    "@unocss/transformer-attributify-jsx@66.1.3": {
+      "integrity": "sha512-9dSacVrxmjiJUDRjK4f7qHcI//MjiApopRWtRrnyFbAzsKTqXHxstVCqYKkzCGRt2JcW01MXd/uL7q0Dw/YSCQ==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/transformer-compile-class@66.1.2": {
-      "integrity": "sha512-viJetYFncLf9llxYQ7DKf5PuSJw08B7qhp0IXv/7ZG7agU09J1mlussC6ff+00iRoMxvG+5uXiYlTzL2vfikwA==",
+    "@unocss/transformer-compile-class@66.1.3": {
+      "integrity": "sha512-cV3qVDvuTM1DXBE9hyP69UU/etrloFrOx93ztjhuznKfCDyjWI79oL95BxSyHfD0bPNWKH9wSqNgesgnQKhkog==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/transformer-directives@66.1.2": {
-      "integrity": "sha512-A41/cPMB+BUEgnhz5kFiTYgSuCAziJy6hSlLYBDcrFbARUsvmhZFou0P2fRr3wDOFxD3BuApHjsefybKTh1UeA==",
+    "@unocss/transformer-directives@66.1.3": {
+      "integrity": "sha512-xo91rCu6o5NEbc9EJrEQA1mKRVVwpstm78vIqKJAhU57QlR7Mj4UDbq46ogkt+jcljKCHppp+9aQXRk/Z4PAZw==",
       "dependencies": [
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/rule-utils",
         "css-tree"
       ]
     },
-    "@unocss/transformer-variant-group@66.1.2": {
-      "integrity": "sha512-RfqJmeic4kAwS5OhSk/D00hqla+xXIw8AJH93jYqHfyDhJR5vddEAJi5RBMOL7y6vDQqRlUCEDQvfp3zSmi6iw==",
+    "@unocss/transformer-variant-group@66.1.3": {
+      "integrity": "sha512-FCB5LB459FTE/E/OXn5g6O/o7AOJbiEDRiA/WXtalB/VLsqc5DHSbb9isITYUTh+PqzZZef8W6+kQjG5wx5yNA==",
       "dependencies": [
-        "@unocss/core@66.1.2"
+        "@unocss/core@66.1.3"
       ]
     },
-    "@unocss/vite@66.1.2_vite@6.2.3": {
-      "integrity": "sha512-ZJHN8+HKSrclVjT/+S7Vh2t59DK8J44d5nLZPG1Goua7uNK8yYJeOLK2sCGX7aackRer1ZynmglFFzxNFVt+IA==",
+    "@unocss/vite@66.1.3_vite@6.3.5__picomatch@4.0.2": {
+      "integrity": "sha512-DBehjzx93XkWK6skudKZ9BewcFoZdbVhn+7tSM00HoDjQ8WHeC22saJf0UY9sAkdq7f2k2enAhAcznr2/DUTng==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/inspector",
         "chokidar@3.6.0",
         "magic-string",
         "pathe@2.0.3",
         "tinyglobby",
         "unplugin-utils",
-        "vite@6.2.3"
+        "vite@6.3.5_picomatch@4.0.2"
       ]
     },
     "@vercel/nft@0.27.7_rollup@4.40.2_acorn@8.14.1": {
@@ -1479,8 +1404,8 @@
         "mini-svg-data-uri"
       ]
     },
-    "@vue/compiler-core@3.5.14": {
-      "integrity": "sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==",
+    "@vue/compiler-core@3.5.16": {
+      "integrity": "sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==",
       "dependencies": [
         "@babel/parser",
         "@vue/shared",
@@ -1489,15 +1414,15 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-dom@3.5.14": {
-      "integrity": "sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==",
+    "@vue/compiler-dom@3.5.16": {
+      "integrity": "sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==",
       "dependencies": [
         "@vue/compiler-core",
         "@vue/shared"
       ]
     },
-    "@vue/compiler-sfc@3.5.14": {
-      "integrity": "sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==",
+    "@vue/compiler-sfc@3.5.16": {
+      "integrity": "sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==",
       "dependencies": [
         "@babel/parser",
         "@vue/compiler-core",
@@ -1510,28 +1435,28 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-ssr@3.5.14": {
-      "integrity": "sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==",
+    "@vue/compiler-ssr@3.5.16": {
+      "integrity": "sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/shared"
       ]
     },
-    "@vue/reactivity@3.5.14": {
-      "integrity": "sha512-7cK1Hp343Fu/SUCCO52vCabjvsYu7ZkOqyYu7bXV9P2yyfjUMUXHZafEbq244sP7gf+EZEz+77QixBTuEqkQQw==",
+    "@vue/reactivity@3.5.16": {
+      "integrity": "sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==",
       "dependencies": [
         "@vue/shared"
       ]
     },
-    "@vue/runtime-core@3.5.14": {
-      "integrity": "sha512-w9JWEANwHXNgieAhxPpEpJa+0V5G0hz3NmjAZwlOebtfKyp2hKxKF0+qSh0Xs6/PhfGihuSdqMprMVcQU/E6ag==",
+    "@vue/runtime-core@3.5.16": {
+      "integrity": "sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/shared"
       ]
     },
-    "@vue/runtime-dom@3.5.14": {
-      "integrity": "sha512-lCfR++IakeI35TVR80QgOelsUIdcKjd65rWAMfdSlCYnaEY5t3hYwru7vvcWaqmrK+LpI7ZDDYiGU5V3xjMacw==",
+    "@vue/runtime-dom@3.5.16": {
+      "integrity": "sha512-T1qqYJsG2xMGhImRUV9y/RseB9d0eCYZQ4CWca9ztCuiPj/XWNNN+lkNBuzVbia5z4/cgxdL28NoQCvC0Xcfww==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/runtime-core",
@@ -1539,16 +1464,16 @@
         "csstype"
       ]
     },
-    "@vue/server-renderer@3.5.14_vue@3.5.14": {
-      "integrity": "sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==",
+    "@vue/server-renderer@3.5.16_vue@3.5.16": {
+      "integrity": "sha512-BrX0qLiv/WugguGsnQUJiYOE0Fe5mZTwi6b7X/ybGB0vfrPH9z0gD/Y6WOR1sGCgX4gc25L1RYS5eYQKDMoNIg==",
       "dependencies": [
         "@vue/compiler-ssr",
         "@vue/shared",
         "vue"
       ]
     },
-    "@vue/shared@3.5.14": {
-      "integrity": "sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ=="
+    "@vue/shared@3.5.16": {
+      "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg=="
     },
     "@whatwg-node/disposablestack@0.0.6": {
       "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
@@ -2430,36 +2355,6 @@
         "@esbuild/win32-x64@0.24.2"
       ]
     },
-    "esbuild@0.25.2": {
-      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
-      "dependencies": [
-        "@esbuild/aix-ppc64@0.25.2",
-        "@esbuild/android-arm64@0.25.2",
-        "@esbuild/android-arm@0.25.2",
-        "@esbuild/android-x64@0.25.2",
-        "@esbuild/darwin-arm64@0.25.2",
-        "@esbuild/darwin-x64@0.25.2",
-        "@esbuild/freebsd-arm64@0.25.2",
-        "@esbuild/freebsd-x64@0.25.2",
-        "@esbuild/linux-arm64@0.25.2",
-        "@esbuild/linux-arm@0.25.2",
-        "@esbuild/linux-ia32@0.25.2",
-        "@esbuild/linux-loong64@0.25.2",
-        "@esbuild/linux-mips64el@0.25.2",
-        "@esbuild/linux-ppc64@0.25.2",
-        "@esbuild/linux-riscv64@0.25.2",
-        "@esbuild/linux-s390x@0.25.2",
-        "@esbuild/linux-x64@0.25.2",
-        "@esbuild/netbsd-arm64@0.25.2",
-        "@esbuild/netbsd-x64@0.25.2",
-        "@esbuild/openbsd-arm64@0.25.2",
-        "@esbuild/openbsd-x64@0.25.2",
-        "@esbuild/sunos-x64@0.25.2",
-        "@esbuild/win32-arm64@0.25.2",
-        "@esbuild/win32-ia32@0.25.2",
-        "@esbuild/win32-x64@0.25.2"
-      ]
-    },
     "esbuild@0.25.4": {
       "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
       "dependencies": [
@@ -3053,8 +2948,8 @@
         "standard-as-callback"
       ]
     },
-    "iovalkey@0.3.1": {
-      "integrity": "sha512-pSmFj/ZDFLP8AzqIAMpNJArhHYNeyqIwfcUULwZv8g6y3eaUGrlnlT7QXLrJAp0yiGCAqe1hPA33x/h5opNP9w==",
+    "iovalkey@0.3.2": {
+      "integrity": "sha512-jGe3ZHI6NzNxjuH4gMgpyd5FnaRduLxkv801EgcdALxnY7f8MjHuZizibk+kRpVmtuePajS54Jv3OlrgAxGXPg==",
       "dependencies": [
         "@iovalkey/commands",
         "cluster-key-slot",
@@ -4794,12 +4689,12 @@
         "normalize-path@2.1.1"
       ]
     },
-    "unocss@66.1.2": {
-      "integrity": "sha512-mVwuXzIZ5Ex83F4w3XVJyp9DSbh5KhDzglyvMLktX8oU0QxQtaSpa5lE1twl3wgM0pVL9gmzD4a0FoYWZuJIDg==",
+    "unocss@66.1.3": {
+      "integrity": "sha512-hjSZ+ekyzVfVNMXeBnTMMatwPP/VaaE9UFyEKJfCctaiex11Dsj1MCjj6PIjGUZyIWzAJp6BZdcVmHyOi09HGw==",
       "dependencies": [
         "@unocss/astro",
         "@unocss/cli",
-        "@unocss/core@66.1.2",
+        "@unocss/core@66.1.3",
         "@unocss/postcss",
         "@unocss/preset-attributify",
         "@unocss/preset-icons",
@@ -4992,15 +4887,6 @@
         "rollup@4.40.2"
       ]
     },
-    "vite@6.2.3": {
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
-      "dependencies": [
-        "esbuild@0.25.2",
-        "fsevents",
-        "postcss",
-        "rollup@4.38.0"
-      ]
-    },
     "vite@6.3.5_picomatch@4.0.2": {
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dependencies": [
@@ -5019,14 +4905,14 @@
         "vite@6.3.5_picomatch@4.0.2"
       ]
     },
-    "vue-flow-layout@0.1.1_vue@3.5.14": {
+    "vue-flow-layout@0.1.1_vue@3.5.16": {
       "integrity": "sha512-JdgRRUVrN0Y2GosA0M68DEbKlXMqJ7FQgsK8CjQD2vxvNSqAU6PZEpi4cfcTVtfM2GVOMjHo7GKKLbXxOBqDqA==",
       "dependencies": [
         "vue"
       ]
     },
-    "vue@3.5.14": {
-      "integrity": "sha512-LbOm50/vZFG6Mhy6KscQYXZMQ0LMCC/y40HDJPPvGFQ+i/lUH+PJHR6C3assgOQiXdl6tAfsXHbXYVBZZu65ew==",
+    "vue@3.5.16": {
+      "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/compiler-sfc",
@@ -5215,13 +5101,13 @@
         "npm:@iconify-json/flowbite@^1.2.5",
         "npm:@solidjs/router@0.15",
         "npm:@solidjs/start@^1.1.4",
-        "npm:@unocss/preset-wind4@^66.1.2",
+        "npm:@unocss/preset-wind4@^66.1.3",
         "npm:@vonagam/unocss-preset-flowbite@^0.0.1",
         "npm:flowbite@^3.1.2",
-        "npm:iovalkey@~0.3.1",
+        "npm:iovalkey@~0.3.2",
         "npm:lean-qr@^2.5.0",
         "npm:solid-js@^1.9.7",
-        "npm:unocss@^66.1.2",
+        "npm:unocss@^66.1.3",
         "npm:vinxi@~0.5.6"
       ]
     }

--- a/services/demo-shop/flake.lock
+++ b/services/demo-shop/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -34,17 +34,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
-        "owner": "nixos",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/services/demo-shop/flake.nix
+++ b/services/demo-shop/flake.nix
@@ -4,21 +4,30 @@
   description = "NixOS docker image";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgs_unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        # unstable = nixpkgs_unstable.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
         default_pkg = pkgs.callPackage ./default.nix {
           inherit pkgs;
           nodejs = pkgs.nodejs_22;

--- a/services/demo-shop/k8s/README.md
+++ b/services/demo-shop/k8s/README.md
@@ -37,6 +37,8 @@ The configuration of the service is done via environment variables. Example envi
 EXTERNAL_HOSTNAME=demo-shop.example.com
 # External hostname of the Verifiable Data Service
 EXTERNAL_VDS_HOSTNAME=demo-shop.vds.example.com
+# authorization token for accessing protected /authrequests endpoints
+VDS_BEARER_TOKEN=testest
 # External hostname of the Embedded Verification Interface
 EXTERNAL_EVI_HOSTNAME=evi.example.com
 # External hostname of the Verification Service Interface

--- a/services/demo-shop/package.json
+++ b/services/demo-shop/package.json
@@ -11,13 +11,13 @@
     "@iconify-json/flowbite": "^1.2.5",
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.4",
-    "@unocss/preset-wind4": "^66.1.2",
+    "@unocss/preset-wind4": "^66.1.3",
     "@vonagam/unocss-preset-flowbite": "^0.0.1",
     "flowbite": "^3.1.2",
-    "iovalkey": "^0.3.1",
+    "iovalkey": "^0.3.2",
     "lean-qr": "^2.5.0",
     "solid-js": "^1.9.7",
-    "unocss": "^66.1.2",
+    "unocss": "^66.1.3",
     "vinxi": "^0.5.6"
   },
   "overrides": {

--- a/services/demo-shop/package.json
+++ b/services/demo-shop/package.json
@@ -11,14 +11,14 @@
     "@iconify-json/flowbite": "^1.2.5",
     "@solidjs/router": "^0.15.0",
     "@solidjs/start": "^1.1.4",
-    "@unocss/preset-wind4": "^66.1.3",
+    "@unocss/preset-wind4": "^66.2.0",
     "@vonagam/unocss-preset-flowbite": "^0.0.1",
     "flowbite": "^3.1.2",
-    "iovalkey": "^0.3.2",
+    "iovalkey": "^0.3.3",
     "lean-qr": "^2.5.0",
     "solid-js": "^1.9.7",
-    "unocss": "^66.1.3",
-    "vinxi": "^0.5.6"
+    "unocss": "^66.2.0",
+    "vinxi": "^0.5.7"
   },
   "overrides": {
     "vite": "5.4.10"

--- a/services/demo-shop/src/app.tsx
+++ b/services/demo-shop/src/app.tsx
@@ -4,7 +4,7 @@ import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import ConfigProvider from "~/components/ConfigContext";
 
-import { onMount, Suspense } from "solid-js";
+import { Suspense } from "solid-js";
 import Nav from "~/components/Nav";
 
 /* import { initFlowbite } from "flowbite"; */

--- a/services/demo-shop/src/components/ConfigContext.tsx
+++ b/services/demo-shop/src/components/ConfigContext.tsx
@@ -1,4 +1,3 @@
-import { createEffect } from "solid-js";
 import { createContext, createResource, onMount, useContext } from "solid-js";
 import { isServer } from "solid-js/web";
 
@@ -19,7 +18,7 @@ export const ConfigContext = createContext([
 
 export default function ConfigProvider(props) {
   /* "use server"; */
-  function fetchConfig(source, { value, refetching }) {
+  function fetchConfig(_source, { value: _value, refetching: _refetching }) {
     /* console.log("source", source); */
     /* console.log("value", value); */
     /* console.log("refetching", refetching); */
@@ -28,7 +27,7 @@ export default function ConfigProvider(props) {
     const url = new URL(document.URL);
     url.pathname = "api/config";
     url.search = "";
-    return fetch(url).then((res) =>
+    return fetch(url, { headers: { Accept: "application/json" } }).then((res) =>
       res.json().then((config) => {
         if (typeof config === "object") {
           return {

--- a/services/demo-shop/src/components/QRCode.tsx
+++ b/services/demo-shop/src/components/QRCode.tsx
@@ -15,20 +15,20 @@ import { generate } from "lean-qr";
  */
 export default function QRCode(props) {
   let oldText;
-  let canvas: any;
+  let canvas;
   let render = false;
   const [generatedQRCode] = createResource(
     () => (props.children),
-    (source, { value, refetching }) => {
+    (source, { value: _value, refetching: _refetching }) => {
       if (source && source != "") {
         const code = generate(source instanceof URL ? source.toString() : source);
         return code;
       }
     },
   );
-  const [_, { mutate, refetch }] = createResource(
+  const [_, { mutate: _mutate, refetch }] = createResource(
     generatedQRCode,
-    (render) => {
+    (_render) => {
       const code = generatedQRCode();
       if (code && canvas) {
         code.toCanvas(canvas);

--- a/services/demo-shop/src/components/verification/Thanks.tsx
+++ b/services/demo-shop/src/components/verification/Thanks.tsx
@@ -11,7 +11,7 @@ import Shield from "~/components/icons/Shield.tsx";
  * <Verify>{url}></Verify>
  * ```
  */
-export default function Thanks(props) {
+export default function Thanks(_props) {
   return (
     <>
       <div class="text-4xl font-bold text-center">Thank you for verifying!</div>

--- a/services/demo-shop/src/routes/api/authrequests/create.tsx
+++ b/services/demo-shop/src/routes/api/authrequests/create.tsx
@@ -1,8 +1,9 @@
 import type { APIEvent } from "@solidjs/start/server";
 import { store } from "~/lib/store.js";
+import process from "node:process";
 /* import { getJson, getValkeyStore } from "~/lib/store_redis.js"; */
 
-export async function POST(event: APIEvent) {
+export function POST(event: APIEvent) {
   console.debug("authrequests/create");
   const params = new URL(event.request.url).searchParams;
   const mobile = params.get("mobile") == "true" ? true : false;
@@ -16,11 +17,17 @@ export async function POST(event: APIEvent) {
   /*   entry = await retry(100).then(() => getJson(store, id)); */
   /* } */
 
+  const headers = new Headers();
+  headers.append("Accept", "application/json");
+  const token = process.env.VDS_BEARER_TOKEN;
+  if (token) {
+    headers.append("Authorization", `Bearer ${token}`);
+  }
   return fetch(
     `https://${process.env.EXTERNAL_VDS_HOSTNAME}/v1/authrequests?nonce=${nonce}`,
-    { method: "POST" },
+    { method: "POST", headers },
   ).then((res) =>
-    res.json().then(async (authRequest) => {
+    res.json().then((authRequest) => {
       console.debug(`Generated nonce ${authRequest.id}/${nonce}`);
       // TODO: test if data doesn't exist yet
       /* await store.set(authRequest.id, JSON.stringify({ nonce, closed: false })); */

--- a/services/demo-shop/src/routes/api/config.tsx
+++ b/services/demo-shop/src/routes/api/config.tsx
@@ -1,9 +1,7 @@
 import type { APIEvent } from "@solidjs/start/server";
 import process from "node:process";
 
-export async function GET(event: APIEvent) {
-  console.debug("config");
-
+export function GET(_event: APIEvent) {
   return {
     "vsi": `https://${process.env.EXTERNAL_VSI_HOSTNAME}`,
   };

--- a/services/demo-shop/src/routes/api/sse/:id.tsx
+++ b/services/demo-shop/src/routes/api/sse/:id.tsx
@@ -1,9 +1,8 @@
-import { json } from "@solidjs/router";
 import type { APIEvent } from "@solidjs/start/server";
 import { connections, store } from "~/lib/store.js";
 /* import { getJson, getValkeyStore } from "~/lib/store_redis.js"; */
 
-export async function GET(event: APIEvent) {
+export function GET(event: APIEvent) {
   console.debug("sse/ID", event.params);
 
   const id = event.params.id;
@@ -28,7 +27,7 @@ export async function GET(event: APIEvent) {
       const stream = new ReadableStream({
         start(controller) {
           connections[id] = controller;
-          const sendKeepAlive = async () => {
+          const sendKeepAlive = () => {
             /* const entry = await getJson(store, id); */
             const entry = store[id];
             if (entry && !entry?.closed) {
@@ -73,10 +72,10 @@ export async function GET(event: APIEvent) {
       /*   console.log("connection status", event.request); */
       /* }, 1000); */
       // Cleanup when the client disconnects
-      event.request.signal.addEventListener("close", async (ev) => {
+      event.request.signal.addEventListener("close", (ev) => {
         console.debug("event.request.signal.addEventListener close", id, ev);
       });
-      event.request.signal.addEventListener("abort", async (ev) => {
+      event.request.signal.addEventListener("abort", (ev) => {
         console.debug("event.request.signal.addEventListener abort", id, ev);
         /* await store.set(id, JSON.stringify({ closed: true })); */
         const entry = store[id];

--- a/services/demo-shop/src/routes/api/sse/:id/:nonce.tsx
+++ b/services/demo-shop/src/routes/api/sse/:id/:nonce.tsx
@@ -1,6 +1,7 @@
 import type { APIEvent } from "@solidjs/start/server";
 /* import { getJson, getValkeyStore } from "~/lib/store_redis.js"; */
 import { connections, store } from "~/lib/store.js";
+import process from "node:process";
 
 /* function retry(delay: number) { */
 /*   return new Promise((resolve) => { */
@@ -34,13 +35,19 @@ export async function GET(event: APIEvent) {
       if (nonce == entry?.nonce) {
         console.debug("event: submitted");
 
+        const headers = new Headers();
+        headers.append("Accept", "application/json");
+        const token = process.env.VDS_BEARER_TOKEN;
+        if (token) {
+          headers.append("Authorization", `Bearer ${token}`);
+        }
         const data = await fetch(
           `https://${process.env.EXTERNAL_VDS_HOSTNAME}/v1/authrequests/${id}`,
-          { method: "GET" },
+          { method: "GET", headers },
         ).then((res) => res.json()).catch((err) =>
           console.error("An error occurred while fetching the results", id, nonce, err)
         );
-        console.log("data", data);
+        /* console.log("data", data); */
         try {
           const presentation_submission = data.presentation_submission;
           let presentation = {};

--- a/services/demo-shop/src/routes/api/sse/:id/data.tsx
+++ b/services/demo-shop/src/routes/api/sse/:id/data.tsx
@@ -12,7 +12,7 @@ import { store } from "~/lib/store.js";
  * Function submits a navigation request to the connected browser window via the existing SSE connection between client
  * and server, the final step in the authorization flow.
  */
-export async function GET(event: APIEvent) {
+export function GET(event: APIEvent) {
   console.debug("sse/ID/data", event.params);
   const { id } = event.params;
 

--- a/services/demo-shop/src/routes/checkout/:id.tsx
+++ b/services/demo-shop/src/routes/checkout/:id.tsx
@@ -1,11 +1,12 @@
-import { createAsync, query, useBeforeLeave, useNavigate, useParams } from "@solidjs/router";
+import { createAsync, query, useParams } from "@solidjs/router";
+import process from "node:process";
 
 const getData = query((id) => {
   "use server";
   console.debug("getData");
   return fetch(
     `https://${process.env.EXTERNAL_HOSTNAME}/api/sse/${id}/data`,
-    { method: "GET" },
+    { method: "GET", headers: { Accept: "application/json" } },
   ).then((res) =>
     res.json().then((credential) => {
       console.debug("getData response", credential);

--- a/services/demo-shop/src/routes/credentials.tsx
+++ b/services/demo-shop/src/routes/credentials.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, onCleanup, Show, Suspense } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { createAsync, query, useBeforeLeave, useNavigate } from "@solidjs/router";
 import isMobile from "~/lib/isMobile.js";
 import process from "node:process";
@@ -12,9 +12,9 @@ const createAuthorizationRequest = query((mobile) => {
   "use server";
   return fetch(
     `https://${process.env.EXTERNAL_HOSTNAME}/api/authrequests/create?mobile=${mobile}`,
-    { method: "POST" },
+    { method: "POST", headers: { Accept: "application/json" } },
   ).then((res) =>
-    res.json().then(async (authRequest) => {
+    res.json().then((authRequest) => {
       console.debug("createAuthorizationRequest response", authRequest);
       return authRequest;
     }).catch((err) => {
@@ -64,7 +64,7 @@ export default function Credentials() {
         /* } */
         /* printConnectionStatus(); */
       };
-      eventSource.onmessage = (event) => {
+      eventSource.onmessage = (_event) => {
         if (eventSourceStatus() != eventSourceStatusOptions.established) {
           console.debug("ignoring message, eventsource", eventSourceStatus());
           return;
@@ -88,7 +88,7 @@ export default function Credentials() {
           navigate(url);
         }, 5000);
       });
-      eventSource.addEventListener("ping", (event) => {
+      eventSource.addEventListener("ping", (_event) => {
         if (eventSourceStatus() != eventSourceStatusOptions.established) {
           console.debug(
             "ignoring ping event, eventsource",
@@ -98,7 +98,7 @@ export default function Credentials() {
         }
         console.debug("event ping" /* event */);
       });
-      eventSource.addEventListener("timeout", (event) => {
+      eventSource.addEventListener("timeout", (_event) => {
         if (eventSourceStatus() != eventSourceStatusOptions.established) {
           console.debug(
             "ignoring timeout event, eventsource",
@@ -131,11 +131,12 @@ export default function Credentials() {
       eventSource?.close();
       console.debug("connection closed", eventSource);
       if (authRequest()?.id) {
-        fetch(`/api/sse/${authRequest()?.id}/cancel`, { method: "POST" }).catch(
-          (
-            err,
-          ) => console.error("Error while canceling request", err),
-        );
+        fetch(`/api/sse/${authRequest()?.id}/cancel`, { method: "POST", headers: { Accept: "application/json" } })
+          .catch(
+            (
+              err,
+            ) => console.error("Error while canceling request", err),
+          );
       }
     } catch (err) {
       console.error("useBeforeLeave", err);

--- a/services/demo-shop/tsconfig.json
+++ b/services/demo-shop/tsconfig.json
@@ -5,6 +5,9 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "lib": [
+      "DOM"
+    ],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "allowJs": true,

--- a/services/embedded-verification-ui/Justfile
+++ b/services/embedded-verification-ui/Justfile
@@ -29,4 +29,4 @@ dev-build: build
 # Serve local assets
 [group('development')]
 serve: build
-    SERVER_CACHE_CONTROL_HEADERS=false SERVER_PORT=$PORT SERVER_DIRECTORY_LISTING=true SERVER_CORS_ALLOW_ORIGINS=* SERVER_ROOT=dist/assets static-web-server
+    SERVER_CACHE_CONTROL_HEADERS=false SERVER_PORT=$PORT SERVER_DIRECTORY_LISTING=true SERVER_ROOT=dist/assets static-web-server

--- a/services/embedded-verification-ui/deno.lock
+++ b/services/embedded-verification-ui/deno.lock
@@ -2,11 +2,11 @@
   "version": "4",
   "specifiers": {
     "npm:@iconify-json/flowbite@^1.2.5": "1.2.5",
-    "npm:@unocss/preset-web-fonts@^66.1.2": "66.1.2",
-    "npm:@unocss/preset-wind4@^66.1.2": "66.1.2",
+    "npm:@unocss/preset-web-fonts@^66.1.3": "66.1.3",
+    "npm:@unocss/preset-wind4@^66.1.3": "66.1.3",
     "npm:solid-js@^1.9.7": "1.9.7_seroval@1.3.1",
     "npm:typescript@^5.7.2": "5.8.3",
-    "npm:unocss@^66.1.2": "66.1.2_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3",
+    "npm:unocss@^66.1.3": "66.1.3_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3",
     "npm:vite-plugin-solid@^2.11.6": "2.11.6_solid-js@1.9.7__seroval@1.3.1_vite@6.3.5__picomatch@4.0.2_@babel+core@7.27.1",
     "npm:vite@^6.3.5": "6.3.5_picomatch@4.0.2"
   },
@@ -290,65 +290,65 @@
         "quansync"
       ]
     },
-    "@rollup/rollup-android-arm-eabi@4.40.2": {
-      "integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg=="
+    "@rollup/rollup-android-arm-eabi@4.41.0": {
+      "integrity": "sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A=="
     },
-    "@rollup/rollup-android-arm64@4.40.2": {
-      "integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw=="
+    "@rollup/rollup-android-arm64@4.41.0": {
+      "integrity": "sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ=="
     },
-    "@rollup/rollup-darwin-arm64@4.40.2": {
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w=="
+    "@rollup/rollup-darwin-arm64@4.41.0": {
+      "integrity": "sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw=="
     },
-    "@rollup/rollup-darwin-x64@4.40.2": {
-      "integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ=="
+    "@rollup/rollup-darwin-x64@4.41.0": {
+      "integrity": "sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ=="
     },
-    "@rollup/rollup-freebsd-arm64@4.40.2": {
-      "integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ=="
+    "@rollup/rollup-freebsd-arm64@4.41.0": {
+      "integrity": "sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg=="
     },
-    "@rollup/rollup-freebsd-x64@4.40.2": {
-      "integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q=="
+    "@rollup/rollup-freebsd-x64@4.41.0": {
+      "integrity": "sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg=="
     },
-    "@rollup/rollup-linux-arm-gnueabihf@4.40.2": {
-      "integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q=="
+    "@rollup/rollup-linux-arm-gnueabihf@4.41.0": {
+      "integrity": "sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA=="
     },
-    "@rollup/rollup-linux-arm-musleabihf@4.40.2": {
-      "integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg=="
+    "@rollup/rollup-linux-arm-musleabihf@4.41.0": {
+      "integrity": "sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg=="
     },
-    "@rollup/rollup-linux-arm64-gnu@4.40.2": {
-      "integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg=="
+    "@rollup/rollup-linux-arm64-gnu@4.41.0": {
+      "integrity": "sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw=="
     },
-    "@rollup/rollup-linux-arm64-musl@4.40.2": {
-      "integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg=="
+    "@rollup/rollup-linux-arm64-musl@4.41.0": {
+      "integrity": "sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ=="
     },
-    "@rollup/rollup-linux-loongarch64-gnu@4.40.2": {
-      "integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw=="
+    "@rollup/rollup-linux-loongarch64-gnu@4.41.0": {
+      "integrity": "sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w=="
     },
-    "@rollup/rollup-linux-powerpc64le-gnu@4.40.2": {
-      "integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q=="
+    "@rollup/rollup-linux-powerpc64le-gnu@4.41.0": {
+      "integrity": "sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg=="
     },
-    "@rollup/rollup-linux-riscv64-gnu@4.40.2": {
-      "integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg=="
+    "@rollup/rollup-linux-riscv64-gnu@4.41.0": {
+      "integrity": "sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A=="
     },
-    "@rollup/rollup-linux-riscv64-musl@4.40.2": {
-      "integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg=="
+    "@rollup/rollup-linux-riscv64-musl@4.41.0": {
+      "integrity": "sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A=="
     },
-    "@rollup/rollup-linux-s390x-gnu@4.40.2": {
-      "integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ=="
+    "@rollup/rollup-linux-s390x-gnu@4.41.0": {
+      "integrity": "sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw=="
     },
-    "@rollup/rollup-linux-x64-gnu@4.40.2": {
-      "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng=="
+    "@rollup/rollup-linux-x64-gnu@4.41.0": {
+      "integrity": "sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ=="
     },
-    "@rollup/rollup-linux-x64-musl@4.40.2": {
-      "integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA=="
+    "@rollup/rollup-linux-x64-musl@4.41.0": {
+      "integrity": "sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg=="
     },
-    "@rollup/rollup-win32-arm64-msvc@4.40.2": {
-      "integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg=="
+    "@rollup/rollup-win32-arm64-msvc@4.41.0": {
+      "integrity": "sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg=="
     },
-    "@rollup/rollup-win32-ia32-msvc@4.40.2": {
-      "integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA=="
+    "@rollup/rollup-win32-ia32-msvc@4.41.0": {
+      "integrity": "sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ=="
     },
-    "@rollup/rollup-win32-x64-msvc@4.40.2": {
-      "integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="
+    "@rollup/rollup-win32-x64-msvc@4.41.0": {
+      "integrity": "sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA=="
     },
     "@types/babel__core@7.20.5": {
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
@@ -382,8 +382,8 @@
     "@types/estree@1.0.7": {
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
-    "@unocss/astro@66.1.2_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
-      "integrity": "sha512-QBcvrPp0F2jqe2Y/S/FQDmEmNlAhGjeWN5fkUGj02N7mXRrg0/VJxSpOJH6XHRWkMoFPoNNyEjHk563ODbjtHw==",
+    "@unocss/astro@66.1.3_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
+      "integrity": "sha512-jsubeNZE/LThm8fXPMWNmNXmG5KsM4LIpJ37rq5tgP6RqX0UwLvA4t9yXNJdr6aLDJN6+KpQXfGhIrf/Aj7YIQ==",
       "dependencies": [
         "@unocss/core",
         "@unocss/reset",
@@ -391,8 +391,8 @@
         "vite"
       ]
     },
-    "@unocss/cli@66.1.2": {
-      "integrity": "sha512-bYCRpkGMu0QwC6Ktq3S/HwtcIW8Famy0dXOu1RIAM1IT60lq+4S5UTEBPdwryoFgDBoVMB7KLUhPYiGQ3pmSTA==",
+    "@unocss/cli@66.1.3": {
+      "integrity": "sha512-7Uw6VDsk7w6E6PkrRfq34d+tJpTcNWfksNkLorpQhwwlpbIod69iNHj5gn5u0SJwrAAuFvGNTQzOWQar8HlKCQ==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
@@ -409,24 +409,24 @@
         "unplugin-utils"
       ]
     },
-    "@unocss/config@66.1.2": {
-      "integrity": "sha512-2sQXj+Qaq4RVDELVTPoXMggZ30g1WKHeCuur396I12Ab0HgAR6bTc/DIrNtqKVHFI3mmlvP1oM1ynhKWSKPsTg==",
+    "@unocss/config@66.1.3": {
+      "integrity": "sha512-oEKomMMY+f6+4HkU538XG7jOJZAMMk2WczT2XS6HdpJWwUzSKHlhs9R2pj7g0HLJZsROzP1A1+OBstHcQLe94A==",
       "dependencies": [
         "@unocss/core",
         "unconfig"
       ]
     },
-    "@unocss/core@66.1.2": {
-      "integrity": "sha512-mN9h1hHEuhDcdbI4z74o7UnxlBZYVsJpYcdC1YLWBKROcLYTkuyZ7hgBzpo1FBNox2Bt3JnrSinVDmc44Bxjow=="
+    "@unocss/core@66.1.3": {
+      "integrity": "sha512-qV88JvRvSMgMo1FMWZfNiKYy+IvaXswyMMyZvuQxCrNkDPtij46pu7G3heKdLl7mNTdSgF0+LQPEqVYVA27pCA=="
     },
-    "@unocss/extractor-arbitrary-variants@66.1.2": {
-      "integrity": "sha512-F570wH9VYeFTb4r8qgcbN5QpEVIAvFC1zOnrAPUr6B6kbU2YChMXxHP7PHK0AzLHnEr458Pwpzl6hmP6bzxZ8g==",
+    "@unocss/extractor-arbitrary-variants@66.1.3": {
+      "integrity": "sha512-4nlQKx40ch+4hjNlN/jWZDd06qbXFj5xwMpnNjDcb008zgCuPK2dEmg/eDddSv25KZh9W+3fvwduMDNK6YDooQ==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/inspector@66.1.2_typescript@5.8.3": {
-      "integrity": "sha512-ftdZzFP5DAKDzgBI078xDDZbNNVq1RV/yhpNkviBvWCUsgRWc6o3G8swqJPIvFaphmUms0RIYH9shmXilVXFtA==",
+    "@unocss/inspector@66.1.3_typescript@5.8.3": {
+      "integrity": "sha512-ntKtc9ZJBrYf6BFZlwfWwDCWKvZQd3A3W4i0NGdHXlzAC3CFGf19U355e49DfKCln6zDtTVHTPWCuMzMH2H52Q==",
       "dependencies": [
         "@unocss/core",
         "@unocss/rule-utils",
@@ -436,8 +436,8 @@
         "vue-flow-layout"
       ]
     },
-    "@unocss/postcss@66.1.2_postcss@8.5.3": {
-      "integrity": "sha512-RCA3or1qBdRVduNW73xdeiFDCEb8cvcGKsHSN66rL66RrlzNnunE4NE55vbI+yoArTRZ7RdUnxq1KuXKjrJbYw==",
+    "@unocss/postcss@66.1.3_postcss@8.5.3": {
+      "integrity": "sha512-kVJlJ19WnG0Ec4BpdJUcUaA/B5md440WiKId2oaD6nzT6IDozpbQ3DwW2HtQ33YyagkmwYgocb0oodEm2lGilA==",
       "dependencies": [
         "@unocss/config",
         "@unocss/core",
@@ -447,117 +447,117 @@
         "tinyglobby"
       ]
     },
-    "@unocss/preset-attributify@66.1.2": {
-      "integrity": "sha512-i7+LRtpxbtSzS+gHdc+aW99mGLYeR8hUnEWqFNnr+MiiyzbD8yFimye/u8TySSBLzPKGbLCb4YWVV684BuZgxA==",
+    "@unocss/preset-attributify@66.1.3": {
+      "integrity": "sha512-geEaGxs7j85P1HirbAlIRnCrJwxjvvbUQDC2TOXUZ67So1co2mac/3uo0QMJsdry14iSIIfu6rNVaDjMSC4K5g==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/preset-icons@66.1.2": {
-      "integrity": "sha512-14390jFBJ2anuKvjX9TeRCm7adNjR/mey0bh0+S/k/5W3VugIY2y0E+OH3m+sx5d/5ZUYbYkUGsmtuKbVNwwxQ==",
+    "@unocss/preset-icons@66.1.3": {
+      "integrity": "sha512-n1y8I4cVfOOldgyuncwtMn8/wMVzUzVvwdgQk2ow/D07TBgsyZZfk98N1AAFrS772SRr8+YmJ5im4+bNLZaYdA==",
       "dependencies": [
         "@iconify/utils",
         "@unocss/core",
         "ofetch"
       ]
     },
-    "@unocss/preset-mini@66.1.2": {
-      "integrity": "sha512-oiDe+VhwZ8B5Z0UGfggtOwgpRZMLtH1RTDFvmJmJEXYYX5BPWknS6wYcQzxy0i/y9ym0xp2QnEaTpGmR7LKdkg==",
+    "@unocss/preset-mini@66.1.3": {
+      "integrity": "sha512-8HYCTl0YK5FGzfVbtshN1MIQfNZy8baT4BLdcDb2qtsLjG5qP7rmqTdk3c8OpoKhGLUuXPXBaDjh+D5TAMBY3w==",
       "dependencies": [
         "@unocss/core",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-tagify@66.1.2": {
-      "integrity": "sha512-Xw5sFJGuzmGnfAXMI0kAiWDBh4DT3cOyphcyY9grBxbmxgqQDxRFHOV3Eg85lWK6X5cScOv3DhO0ndGv5ND8YA==",
+    "@unocss/preset-tagify@66.1.3": {
+      "integrity": "sha512-IUhggch3uaDraTgnomjo9eRIsarI3r3Wy5Cyu5GtmAIs4RIe7MTVsGeL21q7qgC12/UmQ7E9zdyJR1IbQ6L9aQ==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/preset-typography@66.1.2": {
-      "integrity": "sha512-+k9zp27Ak8rB6LPFDwq9fcwd3+ivFeSvXFQ2d4fBCwGGOAKHIA7qHLg3etxRaMhGd3YUPv/6d7FWpBbQgUVYZw==",
+    "@unocss/preset-typography@66.1.3": {
+      "integrity": "sha512-97n8xIYwQlxhor0FiLsmp697G6DTmUauFNv1trJf2d2wBP2W/AAkIbKw0t8SEN06eduvB7Epq7h7502dyULV4A==",
       "dependencies": [
         "@unocss/core",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-uno@66.1.2": {
-      "integrity": "sha512-JL9YkDwluu1YGhzBaxO60XkKtZBagL13z3K6dsjsghbs+dKVlh35rhlIm5TZ+NdLAzcLM8PHhXm2ausjSd54Bg==",
+    "@unocss/preset-uno@66.1.3": {
+      "integrity": "sha512-JM/6cMGX3xSdU2a+S0JOl3aEWlQoOv0J3yyyQgd0lamkWF3RhRON6QZwhcMaLGVAPwVrSfaLG2ucCH9uubGpdg==",
       "dependencies": [
         "@unocss/core",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/preset-web-fonts@66.1.2": {
-      "integrity": "sha512-2ru+6jaac72oUx0kOBgNzbbkVe6oWKjqGmx24uK94fAcrP9eQyd+r7xiFpqXegrQ8+kONI66+HxAClvF2JHqdw==",
+    "@unocss/preset-web-fonts@66.1.3": {
+      "integrity": "sha512-uOWEmru+tbr/gttM6X/sJHoY0TCVdUx8/EiVITrLe51Agi2UECQlCdBH2lZNnfc3RCArCn4JevMLHd1btHRzJg==",
       "dependencies": [
         "@unocss/core",
         "ofetch"
       ]
     },
-    "@unocss/preset-wind3@66.1.2": {
-      "integrity": "sha512-S09imGOngAAOXCBCHb3JAtxD1/L7nDWrgEeX6NT0ElDp3X1T6XxUXYJlpjCfcqV/klMoXyYouKvp0YuG9QSgVg==",
+    "@unocss/preset-wind3@66.1.3": {
+      "integrity": "sha512-oFQKA/v0EbCtZaxTBKvTfyVG1hcDJ1CXQ7gsghynMpOKMJbnb7bq4NEuDoMdHCVV9yKEQaSXkbbyHpeithBO3g==",
       "dependencies": [
         "@unocss/core",
         "@unocss/preset-mini",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind4@66.1.2": {
-      "integrity": "sha512-03p4rpBAWzz58BzAiKsUuG+6YO7IG6mJMGQAtPzuhd+nVBJLIRa3eBIVXOPmAVz1rNx5XPRTAr6PMC7ycdMFRA==",
+    "@unocss/preset-wind4@66.1.3": {
+      "integrity": "sha512-QwPDtQv/Asz1sYT0HcXPROolKwDCCcHqp0kkrO7aOGaVqyTF6ByfT+7cfI+Mv9uKtZejd+kQTUM/1ag8mzj3UA==",
       "dependencies": [
         "@unocss/core",
         "@unocss/extractor-arbitrary-variants",
         "@unocss/rule-utils"
       ]
     },
-    "@unocss/preset-wind@66.1.2": {
-      "integrity": "sha512-O3nIfbTbX/YRMFj7jNb7nHBDV47G79qOmyid4WPFZrPV3BbFAo94d/54kSoDVuc8jAt06YYQH9XC4ZeD59Sr3Q==",
+    "@unocss/preset-wind@66.1.3": {
+      "integrity": "sha512-PA+W1n3b7vXYAp3bD5BoSXVHDVhXPXOpKkEYDhMHL8+z567/dwDVrkZ5vAPsu1s4bW1PLqN/enzKso74TOfDCg==",
       "dependencies": [
         "@unocss/core",
         "@unocss/preset-wind3"
       ]
     },
-    "@unocss/reset@66.1.2": {
-      "integrity": "sha512-njNy/QCpuPKBFeEvhYGwwCe3t8R8JTxONsyUB9NsFOamkF13DSlEB4Yy/QLQfIinbbmx0F/wiej/JGOJk1ecDg=="
+    "@unocss/reset@66.1.3": {
+      "integrity": "sha512-tc8uSka0R0zlfJfOjoLUg0NMT4RQnAe6nyelBXE86qYQaNV2YD7tf2iEWMmbjNwmiIjc8MigHAvYt1HmdirNww=="
     },
-    "@unocss/rule-utils@66.1.2": {
-      "integrity": "sha512-nn0ehvDh7yyWq2mcBDLVpmMAivjRATUroZ8ETinyN1rmfsGesm71R0d1gV3K+Z6YC7a3+dMLc+/qzI7VK3AG/Q==",
+    "@unocss/rule-utils@66.1.3": {
+      "integrity": "sha512-EP8QRcOO/dAD1+RxOnWOiGaIyo4IJQOdqD0nBteZDoL3X9vj6GPUI5yo8f7uR6k0koI/hxJv5BVsfQZSIsVjLA==",
       "dependencies": [
         "@unocss/core",
         "magic-string"
       ]
     },
-    "@unocss/transformer-attributify-jsx@66.1.2": {
-      "integrity": "sha512-PNwxpsQlBlTAyw1apIMyioeAKrLAf7axLDjZ4BW20WH7ql0GUwvMhuO/qzsWDpYWdtSlFnnAdWI2aCxyvhzdCA==",
+    "@unocss/transformer-attributify-jsx@66.1.3": {
+      "integrity": "sha512-9dSacVrxmjiJUDRjK4f7qHcI//MjiApopRWtRrnyFbAzsKTqXHxstVCqYKkzCGRt2JcW01MXd/uL7q0Dw/YSCQ==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/transformer-compile-class@66.1.2": {
-      "integrity": "sha512-viJetYFncLf9llxYQ7DKf5PuSJw08B7qhp0IXv/7ZG7agU09J1mlussC6ff+00iRoMxvG+5uXiYlTzL2vfikwA==",
+    "@unocss/transformer-compile-class@66.1.3": {
+      "integrity": "sha512-cV3qVDvuTM1DXBE9hyP69UU/etrloFrOx93ztjhuznKfCDyjWI79oL95BxSyHfD0bPNWKH9wSqNgesgnQKhkog==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/transformer-directives@66.1.2": {
-      "integrity": "sha512-A41/cPMB+BUEgnhz5kFiTYgSuCAziJy6hSlLYBDcrFbARUsvmhZFou0P2fRr3wDOFxD3BuApHjsefybKTh1UeA==",
+    "@unocss/transformer-directives@66.1.3": {
+      "integrity": "sha512-xo91rCu6o5NEbc9EJrEQA1mKRVVwpstm78vIqKJAhU57QlR7Mj4UDbq46ogkt+jcljKCHppp+9aQXRk/Z4PAZw==",
       "dependencies": [
         "@unocss/core",
         "@unocss/rule-utils",
         "css-tree"
       ]
     },
-    "@unocss/transformer-variant-group@66.1.2": {
-      "integrity": "sha512-RfqJmeic4kAwS5OhSk/D00hqla+xXIw8AJH93jYqHfyDhJR5vddEAJi5RBMOL7y6vDQqRlUCEDQvfp3zSmi6iw==",
+    "@unocss/transformer-variant-group@66.1.3": {
+      "integrity": "sha512-FCB5LB459FTE/E/OXn5g6O/o7AOJbiEDRiA/WXtalB/VLsqc5DHSbb9isITYUTh+PqzZZef8W6+kQjG5wx5yNA==",
       "dependencies": [
         "@unocss/core"
       ]
     },
-    "@unocss/vite@66.1.2_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
-      "integrity": "sha512-ZJHN8+HKSrclVjT/+S7Vh2t59DK8J44d5nLZPG1Goua7uNK8yYJeOLK2sCGX7aackRer1ZynmglFFzxNFVt+IA==",
+    "@unocss/vite@66.1.3_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
+      "integrity": "sha512-DBehjzx93XkWK6skudKZ9BewcFoZdbVhn+7tSM00HoDjQ8WHeC22saJf0UY9sAkdq7f2k2enAhAcznr2/DUTng==",
       "dependencies": [
         "@ampproject/remapping",
         "@unocss/config",
@@ -571,8 +571,8 @@
         "vite"
       ]
     },
-    "@vue/compiler-core@3.5.14": {
-      "integrity": "sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==",
+    "@vue/compiler-core@3.5.16": {
+      "integrity": "sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==",
       "dependencies": [
         "@babel/parser",
         "@vue/shared",
@@ -581,15 +581,15 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-dom@3.5.14": {
-      "integrity": "sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==",
+    "@vue/compiler-dom@3.5.16": {
+      "integrity": "sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==",
       "dependencies": [
         "@vue/compiler-core",
         "@vue/shared"
       ]
     },
-    "@vue/compiler-sfc@3.5.14": {
-      "integrity": "sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==",
+    "@vue/compiler-sfc@3.5.16": {
+      "integrity": "sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==",
       "dependencies": [
         "@babel/parser",
         "@vue/compiler-core",
@@ -602,28 +602,28 @@
         "source-map-js"
       ]
     },
-    "@vue/compiler-ssr@3.5.14": {
-      "integrity": "sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==",
+    "@vue/compiler-ssr@3.5.16": {
+      "integrity": "sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/shared"
       ]
     },
-    "@vue/reactivity@3.5.14": {
-      "integrity": "sha512-7cK1Hp343Fu/SUCCO52vCabjvsYu7ZkOqyYu7bXV9P2yyfjUMUXHZafEbq244sP7gf+EZEz+77QixBTuEqkQQw==",
+    "@vue/reactivity@3.5.16": {
+      "integrity": "sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==",
       "dependencies": [
         "@vue/shared"
       ]
     },
-    "@vue/runtime-core@3.5.14": {
-      "integrity": "sha512-w9JWEANwHXNgieAhxPpEpJa+0V5G0hz3NmjAZwlOebtfKyp2hKxKF0+qSh0Xs6/PhfGihuSdqMprMVcQU/E6ag==",
+    "@vue/runtime-core@3.5.16": {
+      "integrity": "sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/shared"
       ]
     },
-    "@vue/runtime-dom@3.5.14": {
-      "integrity": "sha512-lCfR++IakeI35TVR80QgOelsUIdcKjd65rWAMfdSlCYnaEY5t3hYwru7vvcWaqmrK+LpI7ZDDYiGU5V3xjMacw==",
+    "@vue/runtime-dom@3.5.16": {
+      "integrity": "sha512-T1qqYJsG2xMGhImRUV9y/RseB9d0eCYZQ4CWca9ztCuiPj/XWNNN+lkNBuzVbia5z4/cgxdL28NoQCvC0Xcfww==",
       "dependencies": [
         "@vue/reactivity",
         "@vue/runtime-core",
@@ -631,24 +631,16 @@
         "csstype"
       ]
     },
-    "@vue/server-renderer@3.5.14_vue@3.5.14__typescript@5.8.3": {
-      "integrity": "sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==",
+    "@vue/server-renderer@3.5.16_vue@3.5.16__typescript@5.8.3_typescript@5.8.3": {
+      "integrity": "sha512-BrX0qLiv/WugguGsnQUJiYOE0Fe5mZTwi6b7X/ybGB0vfrPH9z0gD/Y6WOR1sGCgX4gc25L1RYS5eYQKDMoNIg==",
       "dependencies": [
         "@vue/compiler-ssr",
         "@vue/shared",
         "vue"
       ]
     },
-    "@vue/server-renderer@3.5.14_vue@3.5.14__typescript@5.8.3_typescript@5.8.3": {
-      "integrity": "sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==",
-      "dependencies": [
-        "@vue/compiler-ssr",
-        "@vue/shared",
-        "vue"
-      ]
-    },
-    "@vue/shared@3.5.14": {
-      "integrity": "sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ=="
+    "@vue/shared@3.5.16": {
+      "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg=="
     },
     "acorn@8.14.1": {
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="
@@ -741,8 +733,8 @@
     "csstype@3.1.3": {
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "debug@4.4.0": {
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "debug@4.4.1": {
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dependencies": [
         "ms"
       ]
@@ -1000,8 +992,8 @@
         "picomatch@2.3.1"
       ]
     },
-    "rollup@4.40.2": {
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+    "rollup@4.41.0": {
+      "integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
       "dependencies": [
         "@rollup/rollup-android-arm-eabi",
         "@rollup/rollup-android-arm64",
@@ -1101,8 +1093,8 @@
         "quansync"
       ]
     },
-    "unocss@66.1.2_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
-      "integrity": "sha512-mVwuXzIZ5Ex83F4w3XVJyp9DSbh5KhDzglyvMLktX8oU0QxQtaSpa5lE1twl3wgM0pVL9gmzD4a0FoYWZuJIDg==",
+    "unocss@66.1.3_vite@6.3.5__picomatch@4.0.2_typescript@5.8.3": {
+      "integrity": "sha512-hjSZ+ekyzVfVNMXeBnTMMatwPP/VaaE9UFyEKJfCctaiex11Dsj1MCjj6PIjGUZyIWzAJp6BZdcVmHyOi09HGw==",
       "dependencies": [
         "@unocss/astro",
         "@unocss/cli",
@@ -1175,19 +1167,19 @@
         "vite"
       ]
     },
-    "vue-flow-layout@0.1.1_vue@3.5.14__typescript@5.8.3_typescript@5.8.3": {
+    "vue-flow-layout@0.1.1_vue@3.5.16__typescript@5.8.3_typescript@5.8.3": {
       "integrity": "sha512-JdgRRUVrN0Y2GosA0M68DEbKlXMqJ7FQgsK8CjQD2vxvNSqAU6PZEpi4cfcTVtfM2GVOMjHo7GKKLbXxOBqDqA==",
       "dependencies": [
         "vue"
       ]
     },
-    "vue@3.5.14_typescript@5.8.3": {
-      "integrity": "sha512-LbOm50/vZFG6Mhy6KscQYXZMQ0LMCC/y40HDJPPvGFQ+i/lUH+PJHR6C3assgOQiXdl6tAfsXHbXYVBZZu65ew==",
+    "vue@3.5.16_typescript@5.8.3": {
+      "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/compiler-sfc",
         "@vue/runtime-dom",
-        "@vue/server-renderer@3.5.14_vue@3.5.14__typescript@5.8.3_typescript@5.8.3",
+        "@vue/server-renderer",
         "@vue/shared",
         "typescript"
       ]
@@ -1200,11 +1192,11 @@
     "packageJson": {
       "dependencies": [
         "npm:@iconify-json/flowbite@^1.2.5",
-        "npm:@unocss/preset-web-fonts@^66.1.2",
-        "npm:@unocss/preset-wind4@^66.1.2",
+        "npm:@unocss/preset-web-fonts@^66.1.3",
+        "npm:@unocss/preset-wind4@^66.1.3",
         "npm:solid-js@^1.9.7",
         "npm:typescript@^5.7.2",
-        "npm:unocss@^66.1.2",
+        "npm:unocss@^66.1.3",
         "npm:vite-plugin-solid@^2.11.6",
         "npm:vite@^6.3.5"
       ]

--- a/services/embedded-verification-ui/flake.lock
+++ b/services/embedded-verification-ui/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -34,17 +34,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
-        "owner": "nixos",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/services/embedded-verification-ui/flake.nix
+++ b/services/embedded-verification-ui/flake.nix
@@ -4,22 +4,31 @@
   description = "NixOS docker image";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgs_unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        unstable = nixpkgs_unstable.legacyPackages.${system};
-        default_pkg = unstable.callPackage ./default.nix { };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
+        default_pkg = pkgs.unstable.callPackage ./default.nix { };
         manifest = pkgs.lib.importJSON ./manifest.json;
         pkgVersionsEqual =
           x: y:

--- a/services/embedded-verification-ui/package.json
+++ b/services/embedded-verification-ui/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@iconify-json/flowbite": "^1.2.5",
-    "@unocss/preset-wind4": "^66.1.2",
-    "@unocss/preset-web-fonts": "^66.1.2",
-    "unocss": "^66.1.2",
+    "@unocss/preset-wind4": "^66.1.3",
+    "@unocss/preset-web-fonts": "^66.1.3",
+    "unocss": "^66.1.3",
     "solid-js": "^1.9.7"
   }
 }

--- a/services/embedded-verification-ui/src/VerificationStatus.tsx
+++ b/services/embedded-verification-ui/src/VerificationStatus.tsx
@@ -43,8 +43,8 @@ const VerificationStatus: Component = (_props) => {
               }
             >
               <Details
-                close={toggleViewMinimized}
-                toggleView={toggleViewStandard}
+                close={isMobile() ? toggleViewMinimized : toggleViewStandard}
+                toggleView={isMobile() ? toggleViewMinimized : toggleViewStandard}
               />
             </Show>
           </header>

--- a/services/shopify/flake.nix
+++ b/services/shopify/flake.nix
@@ -17,8 +17,17 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        unstable = nixpkgs-unstable.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
         default_pkg = pkgs.callPackage ./default.nix {
           inherit pkgs;
           nodejs = pkgs.nodejs_22;

--- a/services/verifiable-data-service/.env
+++ b/services/verifiable-data-service/.env
@@ -4,6 +4,10 @@ HOST=::1
 SERVICE_NAME=vds
 EXTERNAL_HOSTNAME=${TUNNEL_USER}-${SERVICE_NAME}.${TUNNEL_DOMAIN}
 INTERNAL_HOSTNAME=${SERVICE_NAME}.identinet.io.localhost
+# Optional authorization token for protecting the /authrequests endpoints
+# In a production setup leave this token empty place an API gateway infront of this service that performs the
+# verification of request
+BEARER_TOKEN=testest
 
 # Shop configuration
 

--- a/services/verifiable-data-service/Cargo.lock
+++ b/services/verifiable-data-service/Cargo.lock
@@ -5776,6 +5776,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.9.0",
+ "bytes",
+ "http 1.3.1",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5972,6 +5988,7 @@ dependencies = [
  "ssi-data-integrity-suites",
  "tokio",
  "tower",
+ "tower-http",
  "url",
  "uuid",
 ]

--- a/services/verifiable-data-service/Cargo.toml
+++ b/services/verifiable-data-service/Cargo.toml
@@ -28,6 +28,7 @@ serde_json_path = "0.7"
 p256 = "0.13.2"
 config = "0.15.11"
 clap = "4.5.32"
+tower-http = { version = "0.6.6", features = ["validate-request", "auth"] }
 
 [dev-dependencies]
 tower = { version = "0.5.2", features = ["util"] }

--- a/services/verifiable-data-service/flake.lock
+++ b/services/verifiable-data-service/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -34,17 +34,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
-        "owner": "nixos",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/services/verifiable-data-service/flake.nix
+++ b/services/verifiable-data-service/flake.nix
@@ -4,22 +4,31 @@
   description = "NixOS docker image";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgs_unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        unstable = nixpkgs_unstable.legacyPackages.${system};
-        default_pkg = unstable.callPackage ./default.nix { };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
+        default_pkg = pkgs.unstable.callPackage ./default.nix { };
         manifest = pkgs.lib.importJSON ./manifest.json;
         pkgVersionsEqual =
           x: y:

--- a/services/verifiable-data-service/k8s/README.md
+++ b/services/verifiable-data-service/k8s/README.md
@@ -37,6 +37,10 @@ environment file `verifiable-data-service.env`:
 ```dotenv
 # External hostname
 EXTERNAL_HOSTNAME=demo-shop.vds.example.com
+# Optional authorization token for protecting the /authrequests endpoints
+# In a production setup leave this token empty place an API gateway infront of this service that performs the
+# verification of request
+BEARER_TOKEN=testest
 # Hostname of shop and callback base path
 CALLBACK_HOSTNAME=demo-shop.example.com
 CALLBACK_BASE_PATH=api/sse

--- a/services/verifiable-data-service/src/config.rs
+++ b/services/verifiable-data-service/src/config.rs
@@ -54,7 +54,7 @@ struct CliConfig {
     #[arg(
         long,
         short = 't',
-        help = "Optional access token to protect access to the authorizoation request creation and data retrieval, or set via environment variable BEARER_TOKEN (e.g. 5exmFqoMMkT7Ol4wQCUuLju4jepmd5GHWFITNSn4). In a production environment, use an external Identity and Accuss Management system and API gateway."
+        help = "Optional access token to protect access to the authorizoation request creation and data retrieval, or set via environment variable BEARER_TOKEN (e.g. 5exmFqoMMkT7Ol4wQCUuLju4jepmd5GHWFITNSn4). In a production environment, use an external Identity and Access Management system and API gateway."
     )]
     bearer_token: Option<String>,
 }

--- a/services/verifiable-data-service/src/config.rs
+++ b/services/verifiable-data-service/src/config.rs
@@ -50,6 +50,13 @@ struct CliConfig {
         help = "Verification method, DID + key referefence, or set via environment variable VERIFICATION_METHOD (e.g. did:web:shop.example.com#key1)"
     )]
     verification_method: Option<String>,
+
+    #[arg(
+        long,
+        short = 't',
+        help = "Optional access token to protect access to the authorizoation request creation and data retrieval, or set via environment variable BEARER_TOKEN (e.g. 5exmFqoMMkT7Ol4wQCUuLju4jepmd5GHWFITNSn4). In a production environment, use an external Identity and Accuss Management system and API gateway."
+    )]
+    bearer_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -61,6 +68,7 @@ pub struct AppConfig {
     pub key_path: String,
     pub verification_method: String,
     pub callback_base_path: String,
+    pub bearer_token: Option<String>,
     // log_level: String, // TODO: add
 }
 
@@ -81,7 +89,8 @@ impl AppConfig {
             .set_override_option("callback_hostname", cli.callback_hostname)?
             .set_override_option("key_path", cli.key_path)?
             .set_override_option("verification_method", cli.verification_method)?
-            .set_override_option("callback_base_path", cli.callback_base_path)?;
+            .set_override_option("callback_base_path", cli.callback_base_path)?
+            .set_override_option("bearer_token", cli.bearer_token)?;
         let config: AppConfig = builder.build()?.try_deserialize()?;
         Self::validate(config)
     }

--- a/services/verification-service-ui/flake.lock
+++ b/services/verification-service-ui/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -34,17 +34,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
-        "owner": "nixos",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/services/verification-service-ui/flake.nix
+++ b/services/verification-service-ui/flake.nix
@@ -4,21 +4,30 @@
   description = "NixOS docker image";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgs_unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        # unstable = nixpkgs_unstable.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
         default_pkg = pkgs.callPackage ./default.nix {
           inherit pkgs;
           nodejs = pkgs.nodejs_22;

--- a/services/verification-service/flake.lock
+++ b/services/verification-service/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -34,17 +34,17 @@
         "type": "github"
       }
     },
-    "nixpkgs_unstable": {
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
-        "owner": "nixos",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -54,7 +54,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs_unstable": "nixpkgs_unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/services/verification-service/flake.nix
+++ b/services/verification-service/flake.nix
@@ -4,22 +4,31 @@
   description = "NixOS docker image";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgs_unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs_unstable,
+      nixpkgs-unstable,
       flake-utils,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        unstable = nixpkgs_unstable.legacyPackages.${system};
-        default_pkg = unstable.callPackage ./default.nix { };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (self: super: {
+              unstable = import nixpkgs-unstable {
+                inherit system;
+                # config.allowUnfree = true;
+              };
+            })
+          ];
+        };
+        default_pkg = pkgs.unstable.callPackage ./default.nix { };
         manifest = pkgs.lib.importJSON ./manifest.json;
         pkgVersionsEqual =
           x: y:


### PR DESCRIPTION
Only the changes https://github.com/identinet/check/pull/3/commits/504e416604edf8b3bd9e31501f23c0d896838070 and https://github.com/identinet/check/pull/3/commits/f9fb19084e7f47a14d9d4e9c8d77cbf1976a8e3b are relevant. I based this commit partially on #2 

I added a simple bearer token to VDS and the demo shop. In a production setup the VDS bearer token is left empty and an API gateway is placed in front of VDS that will implement a custom authentication mechanism for protecting the relevant endpoints.